### PR TITLE
docs: update version string to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nRF Connect for Cloud application protocols for long-range devices ![Version 1.0.0](https://img.shields.io/badge/version-1.0.0-brightgreen.svg)
+# nRF Connect for Cloud application protocols for long-range devices ![Version 1.1.0](https://img.shields.io/badge/version-1.1.0-brightgreen.svg)
 
 ![Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiaFNvdXU1SWlMRGFCR3Q5U2tKWnptL3E2SU1VUnNsQ2d5djBBUUpmRXV4cGtjdnJKSXcyVzBtQThpZjIyczVxQkVsUnpYcUJkSUE1NHg2b1l6N0VrWFBvPSIsIml2UGFyYW1ldGVyU3BlYyI6InQvalE2ZWJtVmRIZWMxU2giLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=v1) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrfcloud/application-protocols",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "description": "Contains the application protocol definition for long-range devices connecting to nRF Connect for Cloud",
   "scripts": {


### PR DESCRIPTION
The version string is out of sync with the [releases](https://github.com/nRFCloud/application-protocols/releases).