### PR TITLE
feat: Separating shadow config schema

### DIFF
--- a/__tests__/schemas.spec.ts
+++ b/__tests__/schemas.spec.ts
@@ -50,7 +50,7 @@ describe('Validate examples for the device shadow', () => {
 describe('Validate example for dependencies', () => {
     it('can correctly load device shadow', () => {
         const exampleData = JSON.parse(readFileSync('./schemas/deviceShadow/ipShadow/ipShadow-example.json', 'utf-8'));
-        const valid = getValidationWithDependencies(DeviceShadow.IP, DeviceShadow.Config, exampleData);
+        const valid = getValidationWithDependencies(DeviceShadow.IP, [DeviceShadow.Config], exampleData);
         expect(valid).toBeTruthy();
     }); 
 });

--- a/__tests__/schemas.spec.ts
+++ b/__tests__/schemas.spec.ts
@@ -1,11 +1,13 @@
 import { Schema } from 'ajv';
+import { readFileSync } from 'fs';
+import { DeviceShadow } from '../schemas';
 import {
     getSchemaTestCollection,
     SchemaCollectionName,
     SchemaRecord,
 } from '../testutilities';
 
-import { isValidSchema } from '../utilities';
+import { isValidSchema, getValidationWithDependencies } from '../utilities';
 
 // @ts-ignore
 const testGroup = ({ schemaName, schema, schemaTests }) => {
@@ -43,4 +45,12 @@ describe('Validate examples for the device shadow', () => {
         '$schemaName',
         testGroup,
     );
+});
+
+describe('Validate example for dependencies', () => {
+    it('can correctly load device shadow', () => {
+        const exampleData = JSON.parse(readFileSync('./schemas/deviceShadow/ipShadow/ipShadow-example.json', 'utf-8'));
+        const valid = getValidationWithDependencies(DeviceShadow.IP, DeviceShadow.Config, exampleData);
+        expect(valid).toBeTruthy();
+    }); 
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,9 +8,9 @@ function getDefaultExportFromCjs (x) {
 	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
-var ajv = {exports: {}};
+var _2020 = {exports: {}};
 
-var core$2 = {};
+var core$3 = {};
 
 var validate = {};
 
@@ -225,11 +225,11 @@ class ValueScopeName extends code_1.Name {
     }
     setValue(value, { property, itemIndex }) {
         this.value = value;
-        this.scopePath = code_1._ `.${new code_1.Name(property)}[${itemIndex}]`;
+        this.scopePath = (0, code_1._) `.${new code_1.Name(property)}[${itemIndex}]`;
     }
 }
 exports.ValueScopeName = ValueScopeName;
-const line = code_1._ `\n`;
+const line = (0, code_1._) `\n`;
 class ValueScope extends Scope {
     constructor(opts) {
         super(opts);
@@ -276,7 +276,7 @@ class ValueScope extends Scope {
         return this._reduceValues(values, (name) => {
             if (name.scopePath === undefined)
                 throw new Error(`CodeGen: name "${name}" has no value`);
-            return code_1._ `${scopeName}${name.scopePath}`;
+            return (0, code_1._) `${scopeName}${name.scopePath}`;
         });
     }
     scopeCode(values = this._values, usedValues, getCode) {
@@ -300,10 +300,10 @@ class ValueScope extends Scope {
                 let c = valueCode(name);
                 if (c) {
                     const def = this.opts.es5 ? exports.varKinds.var : exports.varKinds.const;
-                    code = code_1._ `${code}${def} ${name} = ${c};${this.opts._n}`;
+                    code = (0, code_1._) `${code}${def} ${name} = ${c};${this.opts._n}`;
                 }
                 else if ((c = getCode === null || getCode === void 0 ? void 0 : getCode(name))) {
-                    code = code_1._ `${code}${c}${this.opts._n}`;
+                    code = (0, code_1._) `${code}${c}${this.opts._n}`;
                 }
                 else {
                     throw new ValueError(name);
@@ -770,7 +770,7 @@ class CodeGen {
             code.push(key);
             if (key !== value || this.opts.es5) {
                 code.push(":");
-                code_1.addCodeArg(code, value);
+                (0, code_1.addCodeArg)(code, value);
             }
         }
         code.push("}");
@@ -822,8 +822,8 @@ class CodeGen {
         const name = this._scope.toName(nameOrPrefix);
         if (this.opts.es5) {
             const arr = iterable instanceof code_1.Name ? iterable : this.var("_arr", iterable);
-            return this.forRange("_i", 0, code_1._ `${arr}.length`, (i) => {
-                this.var(name, code_1._ `${arr}[${i}]`);
+            return this.forRange("_i", 0, (0, code_1._) `${arr}.length`, (i) => {
+                this.var(name, (0, code_1._) `${arr}[${i}]`);
                 forBody(name);
             });
         }
@@ -833,7 +833,7 @@ class CodeGen {
     // With option `ownProperties` replaced with a `for-of` loop for object keys
     forIn(nameOrPrefix, obj, forBody, varKind = this.opts.es5 ? scope_1.varKinds.var : scope_1.varKinds.const) {
         if (this.opts.ownProperties) {
-            return this.forOf(nameOrPrefix, code_1._ `Object.keys(${obj})`, forBody);
+            return this.forOf(nameOrPrefix, (0, code_1._) `Object.keys(${obj})`, forBody);
         }
         const name = this._scope.toName(nameOrPrefix);
         return this._for(new ForIter("in", varKind, name, obj), () => forBody(name));
@@ -993,7 +993,7 @@ function subtractNames(names, from) {
         names[n] = (names[n] || 0) - (from[n] || 0);
 }
 function not(x) {
-    return typeof x == "boolean" || typeof x == "number" || x === null ? !x : code_1._ `!${par(x)}`;
+    return typeof x == "boolean" || typeof x == "number" || x === null ? !x : (0, code_1._) `!${par(x)}`;
 }
 exports.not = not;
 const andCode = mappend(exports.operators.AND);
@@ -1009,10 +1009,10 @@ function or(...args) {
 }
 exports.or = or;
 function mappend(op) {
-    return (x, y) => (x === code_1.nil ? y : y === code_1.nil ? x : code_1._ `${par(x)} ${op} ${par(y)}`);
+    return (x, y) => (x === code_1.nil ? y : y === code_1.nil ? x : (0, code_1._) `${par(x)} ${op} ${par(y)}`);
 }
 function par(x) {
-    return x instanceof code_1.Name ? x : code_1._ `(${x})`;
+    return x instanceof code_1.Name ? x : (0, code_1._) `(${x})`;
 }
 
 }(codegen));
@@ -1077,9 +1077,9 @@ function schemaRefOrVal({ topSchemaRef, schemaPath }, schema, keyword, $data) {
         if (typeof schema == "number" || typeof schema == "boolean")
             return schema;
         if (typeof schema == "string")
-            return codegen_1._ `${schema}`;
+            return (0, codegen_1._) `${schema}`;
     }
-    return codegen_1._ `${topSchemaRef}${schemaPath}${codegen_1.getProperty(keyword)}`;
+    return (0, codegen_1._) `${topSchemaRef}${schemaPath}${(0, codegen_1.getProperty)(keyword)}`;
 }
 exports.schemaRefOrVal = schemaRefOrVal;
 function unescapeFragment(str) {
@@ -1124,15 +1124,15 @@ function makeMergeEvaluated({ mergeNames, mergeToName, mergeValues, resultToName
 }
 exports.mergeEvaluated = {
     props: makeMergeEvaluated({
-        mergeNames: (gen, from, to) => gen.if(codegen_1._ `${to} !== true && ${from} !== undefined`, () => {
-            gen.if(codegen_1._ `${from} === true`, () => gen.assign(to, true), () => gen.assign(to, codegen_1._ `${to} || {}`).code(codegen_1._ `Object.assign(${to}, ${from})`));
+        mergeNames: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true && ${from} !== undefined`, () => {
+            gen.if((0, codegen_1._) `${from} === true`, () => gen.assign(to, true), () => gen.assign(to, (0, codegen_1._) `${to} || {}`).code((0, codegen_1._) `Object.assign(${to}, ${from})`));
         }),
-        mergeToName: (gen, from, to) => gen.if(codegen_1._ `${to} !== true`, () => {
+        mergeToName: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true`, () => {
             if (from === true) {
                 gen.assign(to, true);
             }
             else {
-                gen.assign(to, codegen_1._ `${to} || {}`);
+                gen.assign(to, (0, codegen_1._) `${to} || {}`);
                 setEvaluated(gen, to, from);
             }
         }),
@@ -1140,8 +1140,8 @@ exports.mergeEvaluated = {
         resultToName: evaluatedPropsToName,
     }),
     items: makeMergeEvaluated({
-        mergeNames: (gen, from, to) => gen.if(codegen_1._ `${to} !== true && ${from} !== undefined`, () => gen.assign(to, codegen_1._ `${from} === true ? true : ${to} > ${from} ? ${to} : ${from}`)),
-        mergeToName: (gen, from, to) => gen.if(codegen_1._ `${to} !== true`, () => gen.assign(to, from === true ? true : codegen_1._ `${to} > ${from} ? ${to} : ${from}`)),
+        mergeNames: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true && ${from} !== undefined`, () => gen.assign(to, (0, codegen_1._) `${from} === true ? true : ${to} > ${from} ? ${to} : ${from}`)),
+        mergeToName: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true`, () => gen.assign(to, from === true ? true : (0, codegen_1._) `${to} > ${from} ? ${to} : ${from}`)),
         mergeValues: (from, to) => (from === true ? true : Math.max(from, to)),
         resultToName: (gen, items) => gen.var("items", items),
     }),
@@ -1149,14 +1149,14 @@ exports.mergeEvaluated = {
 function evaluatedPropsToName(gen, ps) {
     if (ps === true)
         return gen.var("props", true);
-    const props = gen.var("props", codegen_1._ `{}`);
+    const props = gen.var("props", (0, codegen_1._) `{}`);
     if (ps !== undefined)
         setEvaluated(gen, props, ps);
     return props;
 }
 exports.evaluatedPropsToName = evaluatedPropsToName;
 function setEvaluated(gen, props, ps) {
-    Object.keys(ps).forEach((p) => gen.assign(codegen_1._ `${props}${codegen_1.getProperty(p)}`, true));
+    Object.keys(ps).forEach((p) => gen.assign((0, codegen_1._) `${props}${(0, codegen_1.getProperty)(p)}`, true));
 }
 exports.setEvaluated = setEvaluated;
 const snippets = {};
@@ -1178,13 +1178,13 @@ function getErrorPath(dataProp, dataPropType, jsPropertySyntax) {
         const isNumber = dataPropType === Type.Num;
         return jsPropertySyntax
             ? isNumber
-                ? codegen_1._ `"[" + ${dataProp} + "]"`
-                : codegen_1._ `"['" + ${dataProp} + "']"`
+                ? (0, codegen_1._) `"[" + ${dataProp} + "]"`
+                : (0, codegen_1._) `"['" + ${dataProp} + "']"`
             : isNumber
-                ? codegen_1._ `"/" + ${dataProp}`
-                : codegen_1._ `"/" + ${dataProp}.replace(/~/g, "~0").replace(/\\//g, "~1")`; // TODO maybe use global escapePointer
+                ? (0, codegen_1._) `"/" + ${dataProp}`
+                : (0, codegen_1._) `"/" + ${dataProp}.replace(/~/g, "~0").replace(/\\//g, "~1")`; // TODO maybe use global escapePointer
     }
-    return jsPropertySyntax ? codegen_1.getProperty(dataProp).toString() : "/" + escapeJsonPointer(dataProp);
+    return jsPropertySyntax ? (0, codegen_1.getProperty)(dataProp).toString() : "/" + escapeJsonPointer(dataProp);
 }
 exports.getErrorPath = getErrorPath;
 function checkStrictMode(it, msg, mode = it.opts.strictSchema) {
@@ -1202,29 +1202,29 @@ exports.checkStrictMode = checkStrictMode;
 var names$1 = {};
 
 Object.defineProperty(names$1, "__esModule", { value: true });
-const codegen_1$t = codegen;
+const codegen_1$x = codegen;
 const names = {
     // validation function arguments
-    data: new codegen_1$t.Name("data"),
+    data: new codegen_1$x.Name("data"),
     // args passed from referencing schema
-    valCxt: new codegen_1$t.Name("valCxt"),
-    instancePath: new codegen_1$t.Name("instancePath"),
-    parentData: new codegen_1$t.Name("parentData"),
-    parentDataProperty: new codegen_1$t.Name("parentDataProperty"),
-    rootData: new codegen_1$t.Name("rootData"),
-    dynamicAnchors: new codegen_1$t.Name("dynamicAnchors"),
+    valCxt: new codegen_1$x.Name("valCxt"),
+    instancePath: new codegen_1$x.Name("instancePath"),
+    parentData: new codegen_1$x.Name("parentData"),
+    parentDataProperty: new codegen_1$x.Name("parentDataProperty"),
+    rootData: new codegen_1$x.Name("rootData"),
+    dynamicAnchors: new codegen_1$x.Name("dynamicAnchors"),
     // function scoped variables
-    vErrors: new codegen_1$t.Name("vErrors"),
-    errors: new codegen_1$t.Name("errors"),
-    this: new codegen_1$t.Name("this"),
+    vErrors: new codegen_1$x.Name("vErrors"),
+    errors: new codegen_1$x.Name("errors"),
+    this: new codegen_1$x.Name("this"),
     // "globals"
-    self: new codegen_1$t.Name("self"),
-    scope: new codegen_1$t.Name("scope"),
+    self: new codegen_1$x.Name("self"),
+    scope: new codegen_1$x.Name("scope"),
     // JTD serialize/parse name for JSON string and position
-    json: new codegen_1$t.Name("json"),
-    jsonPos: new codegen_1$t.Name("jsonPos"),
-    jsonLen: new codegen_1$t.Name("jsonLen"),
-    jsonPart: new codegen_1$t.Name("jsonPart"),
+    json: new codegen_1$x.Name("json"),
+    jsonPos: new codegen_1$x.Name("jsonPos"),
+    jsonLen: new codegen_1$x.Name("jsonLen"),
+    jsonPart: new codegen_1$x.Name("jsonPart"),
 };
 names$1.default = names;
 
@@ -1235,12 +1235,12 @@ const codegen_1 = codegen;
 const util_1 = util;
 const names_1 = names$1;
 exports.keywordError = {
-    message: ({ keyword }) => codegen_1.str `should pass "${keyword}" keyword validation`,
+    message: ({ keyword }) => (0, codegen_1.str) `must pass "${keyword}" keyword validation`,
 };
 exports.keyword$DataError = {
     message: ({ keyword, schemaType }) => schemaType
-        ? codegen_1.str `"${keyword}" keyword must be ${schemaType} ($data)`
-        : codegen_1.str `"${keyword}" keyword is invalid ($data)`,
+        ? (0, codegen_1.str) `"${keyword}" keyword must be ${schemaType} ($data)`
+        : (0, codegen_1.str) `"${keyword}" keyword is invalid ($data)`,
 };
 function reportError(cxt, error = exports.keywordError, errorPaths, overrideAllErrors) {
     const { it } = cxt;
@@ -1250,7 +1250,7 @@ function reportError(cxt, error = exports.keywordError, errorPaths, overrideAllE
         addError(gen, errObj);
     }
     else {
-        returnErrors(it, codegen_1._ `[${errObj}]`);
+        returnErrors(it, (0, codegen_1._) `[${errObj}]`);
     }
 }
 exports.reportError = reportError;
@@ -1266,7 +1266,7 @@ function reportExtraError(cxt, error = exports.keywordError, errorPaths) {
 exports.reportExtraError = reportExtraError;
 function resetErrorsCount(gen, errsCount) {
     gen.assign(names_1.default.errors, errsCount);
-    gen.if(codegen_1._ `${names_1.default.vErrors} !== null`, () => gen.if(errsCount, () => gen.assign(codegen_1._ `${names_1.default.vErrors}.length`, errsCount), () => gen.assign(names_1.default.vErrors, null)));
+    gen.if((0, codegen_1._) `${names_1.default.vErrors} !== null`, () => gen.if(errsCount, () => gen.assign((0, codegen_1._) `${names_1.default.vErrors}.length`, errsCount), () => gen.assign(names_1.default.vErrors, null)));
 }
 exports.resetErrorsCount = resetErrorsCount;
 function extendErrors({ gen, keyword, schemaValue, data, errsCount, it, }) {
@@ -1275,28 +1275,28 @@ function extendErrors({ gen, keyword, schemaValue, data, errsCount, it, }) {
         throw new Error("ajv implementation error");
     const err = gen.name("err");
     gen.forRange("i", errsCount, names_1.default.errors, (i) => {
-        gen.const(err, codegen_1._ `${names_1.default.vErrors}[${i}]`);
-        gen.if(codegen_1._ `${err}.instancePath === undefined`, () => gen.assign(codegen_1._ `${err}.instancePath`, codegen_1.strConcat(names_1.default.instancePath, it.errorPath)));
-        gen.assign(codegen_1._ `${err}.schemaPath`, codegen_1.str `${it.errSchemaPath}/${keyword}`);
+        gen.const(err, (0, codegen_1._) `${names_1.default.vErrors}[${i}]`);
+        gen.if((0, codegen_1._) `${err}.instancePath === undefined`, () => gen.assign((0, codegen_1._) `${err}.instancePath`, (0, codegen_1.strConcat)(names_1.default.instancePath, it.errorPath)));
+        gen.assign((0, codegen_1._) `${err}.schemaPath`, (0, codegen_1.str) `${it.errSchemaPath}/${keyword}`);
         if (it.opts.verbose) {
-            gen.assign(codegen_1._ `${err}.schema`, schemaValue);
-            gen.assign(codegen_1._ `${err}.data`, data);
+            gen.assign((0, codegen_1._) `${err}.schema`, schemaValue);
+            gen.assign((0, codegen_1._) `${err}.data`, data);
         }
     });
 }
 exports.extendErrors = extendErrors;
 function addError(gen, errObj) {
     const err = gen.const("err", errObj);
-    gen.if(codegen_1._ `${names_1.default.vErrors} === null`, () => gen.assign(names_1.default.vErrors, codegen_1._ `[${err}]`), codegen_1._ `${names_1.default.vErrors}.push(${err})`);
-    gen.code(codegen_1._ `${names_1.default.errors}++`);
+    gen.if((0, codegen_1._) `${names_1.default.vErrors} === null`, () => gen.assign(names_1.default.vErrors, (0, codegen_1._) `[${err}]`), (0, codegen_1._) `${names_1.default.vErrors}.push(${err})`);
+    gen.code((0, codegen_1._) `${names_1.default.errors}++`);
 }
 function returnErrors(it, errs) {
     const { gen, validateName, schemaEnv } = it;
     if (schemaEnv.$async) {
-        gen.throw(codegen_1._ `new ${it.ValidationError}(${errs})`);
+        gen.throw((0, codegen_1._) `new ${it.ValidationError}(${errs})`);
     }
     else {
-        gen.assign(codegen_1._ `${validateName}.errors`, errs);
+        gen.assign((0, codegen_1._) `${validateName}.errors`, errs);
         gen.return(false);
     }
 }
@@ -1312,7 +1312,7 @@ const E = {
 function errorObjectCode(cxt, error, errorPaths) {
     const { createErrors } = cxt.it;
     if (createErrors === false)
-        return codegen_1._ `{}`;
+        return (0, codegen_1._) `{}`;
     return errorObject(cxt, error, errorPaths);
 }
 function errorObject(cxt, error, errorPaths = {}) {
@@ -1326,26 +1326,26 @@ function errorObject(cxt, error, errorPaths = {}) {
 }
 function errorInstancePath({ errorPath }, { instancePath }) {
     const instPath = instancePath
-        ? codegen_1.str `${errorPath}${util_1.getErrorPath(instancePath, util_1.Type.Str)}`
+        ? (0, codegen_1.str) `${errorPath}${(0, util_1.getErrorPath)(instancePath, util_1.Type.Str)}`
         : errorPath;
-    return [names_1.default.instancePath, codegen_1.strConcat(names_1.default.instancePath, instPath)];
+    return [names_1.default.instancePath, (0, codegen_1.strConcat)(names_1.default.instancePath, instPath)];
 }
 function errorSchemaPath({ keyword, it: { errSchemaPath } }, { schemaPath, parentSchema }) {
-    let schPath = parentSchema ? errSchemaPath : codegen_1.str `${errSchemaPath}/${keyword}`;
+    let schPath = parentSchema ? errSchemaPath : (0, codegen_1.str) `${errSchemaPath}/${keyword}`;
     if (schemaPath) {
-        schPath = codegen_1.str `${schPath}${util_1.getErrorPath(schemaPath, util_1.Type.Str)}`;
+        schPath = (0, codegen_1.str) `${schPath}${(0, util_1.getErrorPath)(schemaPath, util_1.Type.Str)}`;
     }
     return [E.schemaPath, schPath];
 }
 function extraErrorProps(cxt, { params, message }, keyValues) {
     const { keyword, data, schemaValue, it } = cxt;
     const { opts, propertyName, topSchemaRef, schemaPath } = it;
-    keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || codegen_1._ `{}`]);
+    keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || (0, codegen_1._) `{}`]);
     if (opts.messages) {
         keyValues.push([E.message, typeof message == "function" ? message(cxt) : message]);
     }
     if (opts.verbose) {
-        keyValues.push([E.schema, schemaValue], [E.parentSchema, codegen_1._ `${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
+        keyValues.push([E.schema, schemaValue], [E.parentSchema, (0, codegen_1._) `${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
     }
     if (propertyName)
         keyValues.push([E.propertyName, propertyName]);
@@ -1356,8 +1356,8 @@ function extraErrorProps(cxt, { params, message }, keyValues) {
 Object.defineProperty(boolSchema, "__esModule", { value: true });
 boolSchema.boolOrEmptySchema = boolSchema.topBoolOrEmptySchema = void 0;
 const errors_1$2 = errors;
-const codegen_1$s = codegen;
-const names_1$6 = names$1;
+const codegen_1$w = codegen;
+const names_1$9 = names$1;
 const boolError = {
     message: "boolean schema is false",
 };
@@ -1367,10 +1367,10 @@ function topBoolOrEmptySchema(it) {
         falseSchemaError(it, false);
     }
     else if (typeof schema == "object" && schema.$async === true) {
-        gen.return(names_1$6.default.data);
+        gen.return(names_1$9.default.data);
     }
     else {
-        gen.assign(codegen_1$s._ `${validateName}.errors`, null);
+        gen.assign((0, codegen_1$w._) `${validateName}.errors`, null);
         gen.return(true);
     }
 }
@@ -1399,7 +1399,7 @@ function falseSchemaError(it, overrideAllErrors) {
         params: {},
         it,
     };
-    errors_1$2.reportError(cxt, boolError, undefined, overrideAllErrors);
+    (0, errors_1$2.reportError)(cxt, boolError, undefined, overrideAllErrors);
 }
 
 var dataType = {};
@@ -1492,7 +1492,7 @@ function coerceAndCheckDataType(it, types) {
     const { gen, data, opts } = it;
     const coerceTo = coerceToTypes(types, opts.coerceTypes);
     const checkTypes = types.length > 0 &&
-        !(coerceTo.length === 0 && types.length === 1 && applicability_1.schemaHasRulesForType(it, types[0]));
+        !(coerceTo.length === 0 && types.length === 1 && (0, applicability_1.schemaHasRulesForType)(it, types[0]));
     if (checkTypes) {
         const wrongType = checkDataTypes(types, data, opts.strictNumbers, DataType.Wrong);
         gen.if(wrongType, () => {
@@ -1513,15 +1513,15 @@ function coerceToTypes(types, coerceTypes) {
 }
 function coerceData(it, types, coerceTo) {
     const { gen, data, opts } = it;
-    const dataType = gen.let("dataType", codegen_1._ `typeof ${data}`);
-    const coerced = gen.let("coerced", codegen_1._ `undefined`);
+    const dataType = gen.let("dataType", (0, codegen_1._) `typeof ${data}`);
+    const coerced = gen.let("coerced", (0, codegen_1._) `undefined`);
     if (opts.coerceTypes === "array") {
-        gen.if(codegen_1._ `${dataType} == 'object' && Array.isArray(${data}) && ${data}.length == 1`, () => gen
-            .assign(data, codegen_1._ `${data}[0]`)
-            .assign(dataType, codegen_1._ `typeof ${data}`)
+        gen.if((0, codegen_1._) `${dataType} == 'object' && Array.isArray(${data}) && ${data}.length == 1`, () => gen
+            .assign(data, (0, codegen_1._) `${data}[0]`)
+            .assign(dataType, (0, codegen_1._) `typeof ${data}`)
             .if(checkDataTypes(types, data, opts.strictNumbers), () => gen.assign(coerced, data)));
     }
-    gen.if(codegen_1._ `${coerced} !== undefined`);
+    gen.if((0, codegen_1._) `${coerced} !== undefined`);
     for (const t of coerceTo) {
         if (COERCIBLE.has(t) || (t === "array" && opts.coerceTypes === "array")) {
             coerceSpecificType(t);
@@ -1530,7 +1530,7 @@ function coerceData(it, types, coerceTo) {
     gen.else();
     reportTypeError(it);
     gen.endIf();
-    gen.if(codegen_1._ `${coerced} !== undefined`, () => {
+    gen.if((0, codegen_1._) `${coerced} !== undefined`, () => {
         gen.assign(data, coerced);
         assignParentData(it, coerced);
     });
@@ -1538,70 +1538,70 @@ function coerceData(it, types, coerceTo) {
         switch (t) {
             case "string":
                 gen
-                    .elseIf(codegen_1._ `${dataType} == "number" || ${dataType} == "boolean"`)
-                    .assign(coerced, codegen_1._ `"" + ${data}`)
-                    .elseIf(codegen_1._ `${data} === null`)
-                    .assign(coerced, codegen_1._ `""`);
+                    .elseIf((0, codegen_1._) `${dataType} == "number" || ${dataType} == "boolean"`)
+                    .assign(coerced, (0, codegen_1._) `"" + ${data}`)
+                    .elseIf((0, codegen_1._) `${data} === null`)
+                    .assign(coerced, (0, codegen_1._) `""`);
                 return;
             case "number":
                 gen
-                    .elseIf(codegen_1._ `${dataType} == "boolean" || ${data} === null
+                    .elseIf((0, codegen_1._) `${dataType} == "boolean" || ${data} === null
               || (${dataType} == "string" && ${data} && ${data} == +${data})`)
-                    .assign(coerced, codegen_1._ `+${data}`);
+                    .assign(coerced, (0, codegen_1._) `+${data}`);
                 return;
             case "integer":
                 gen
-                    .elseIf(codegen_1._ `${dataType} === "boolean" || ${data} === null
+                    .elseIf((0, codegen_1._) `${dataType} === "boolean" || ${data} === null
               || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1))`)
-                    .assign(coerced, codegen_1._ `+${data}`);
+                    .assign(coerced, (0, codegen_1._) `+${data}`);
                 return;
             case "boolean":
                 gen
-                    .elseIf(codegen_1._ `${data} === "false" || ${data} === 0 || ${data} === null`)
+                    .elseIf((0, codegen_1._) `${data} === "false" || ${data} === 0 || ${data} === null`)
                     .assign(coerced, false)
-                    .elseIf(codegen_1._ `${data} === "true" || ${data} === 1`)
+                    .elseIf((0, codegen_1._) `${data} === "true" || ${data} === 1`)
                     .assign(coerced, true);
                 return;
             case "null":
-                gen.elseIf(codegen_1._ `${data} === "" || ${data} === 0 || ${data} === false`);
+                gen.elseIf((0, codegen_1._) `${data} === "" || ${data} === 0 || ${data} === false`);
                 gen.assign(coerced, null);
                 return;
             case "array":
                 gen
-                    .elseIf(codegen_1._ `${dataType} === "string" || ${dataType} === "number"
+                    .elseIf((0, codegen_1._) `${dataType} === "string" || ${dataType} === "number"
               || ${dataType} === "boolean" || ${data} === null`)
-                    .assign(coerced, codegen_1._ `[${data}]`);
+                    .assign(coerced, (0, codegen_1._) `[${data}]`);
         }
     }
 }
 function assignParentData({ gen, parentData, parentDataProperty }, expr) {
     // TODO use gen.property
-    gen.if(codegen_1._ `${parentData} !== undefined`, () => gen.assign(codegen_1._ `${parentData}[${parentDataProperty}]`, expr));
+    gen.if((0, codegen_1._) `${parentData} !== undefined`, () => gen.assign((0, codegen_1._) `${parentData}[${parentDataProperty}]`, expr));
 }
 function checkDataType(dataType, data, strictNums, correct = DataType.Correct) {
     const EQ = correct === DataType.Correct ? codegen_1.operators.EQ : codegen_1.operators.NEQ;
     let cond;
     switch (dataType) {
         case "null":
-            return codegen_1._ `${data} ${EQ} null`;
+            return (0, codegen_1._) `${data} ${EQ} null`;
         case "array":
-            cond = codegen_1._ `Array.isArray(${data})`;
+            cond = (0, codegen_1._) `Array.isArray(${data})`;
             break;
         case "object":
-            cond = codegen_1._ `${data} && typeof ${data} == "object" && !Array.isArray(${data})`;
+            cond = (0, codegen_1._) `${data} && typeof ${data} == "object" && !Array.isArray(${data})`;
             break;
         case "integer":
-            cond = numCond(codegen_1._ `!(${data} % 1) && !isNaN(${data})`);
+            cond = numCond((0, codegen_1._) `!(${data} % 1) && !isNaN(${data})`);
             break;
         case "number":
             cond = numCond();
             break;
         default:
-            return codegen_1._ `typeof ${data} ${EQ} ${dataType}`;
+            return (0, codegen_1._) `typeof ${data} ${EQ} ${dataType}`;
     }
-    return correct === DataType.Correct ? cond : codegen_1.not(cond);
+    return correct === DataType.Correct ? cond : (0, codegen_1.not)(cond);
     function numCond(_cond = codegen_1.nil) {
-        return codegen_1.and(codegen_1._ `typeof ${data} == "number"`, _cond, strictNums ? codegen_1._ `isFinite(${data})` : codegen_1.nil);
+        return (0, codegen_1.and)((0, codegen_1._) `typeof ${data} == "number"`, _cond, strictNums ? (0, codegen_1._) `isFinite(${data})` : codegen_1.nil);
     }
 }
 exports.checkDataType = checkDataType;
@@ -1610,10 +1610,10 @@ function checkDataTypes(dataTypes, data, strictNums, correct) {
         return checkDataType(dataTypes[0], data, strictNums, correct);
     }
     let cond;
-    const types = util_1.toHash(dataTypes);
+    const types = (0, util_1.toHash)(dataTypes);
     if (types.array && types.object) {
-        const notObj = codegen_1._ `typeof ${data} != "object"`;
-        cond = types.null ? notObj : codegen_1._ `!${data} || ${notObj}`;
+        const notObj = (0, codegen_1._) `typeof ${data} != "object"`;
+        cond = types.null ? notObj : (0, codegen_1._) `!${data} || ${notObj}`;
         delete types.null;
         delete types.array;
         delete types.object;
@@ -1624,22 +1624,22 @@ function checkDataTypes(dataTypes, data, strictNums, correct) {
     if (types.number)
         delete types.integer;
     for (const t in types)
-        cond = codegen_1.and(cond, checkDataType(t, data, strictNums, correct));
+        cond = (0, codegen_1.and)(cond, checkDataType(t, data, strictNums, correct));
     return cond;
 }
 exports.checkDataTypes = checkDataTypes;
 const typeError = {
     message: ({ schema }) => `must be ${schema}`,
-    params: ({ schema, schemaValue }) => typeof schema == "string" ? codegen_1._ `{type: ${schema}}` : codegen_1._ `{type: ${schemaValue}}`,
+    params: ({ schema, schemaValue }) => typeof schema == "string" ? (0, codegen_1._) `{type: ${schema}}` : (0, codegen_1._) `{type: ${schemaValue}}`,
 };
 function reportTypeError(it) {
     const cxt = getTypeErrorContext(it);
-    errors_1.reportError(cxt, typeError);
+    (0, errors_1.reportError)(cxt, typeError);
 }
 exports.reportTypeError = reportTypeError;
 function getTypeErrorContext(it) {
     const { gen, data, schema } = it;
-    const schemaCode = util_1.schemaRefOrVal(it, schema, "type");
+    const schemaCode = (0, util_1.schemaRefOrVal)(it, schema, "type");
     return {
         gen,
         keyword: "type",
@@ -1659,8 +1659,8 @@ var defaults = {};
 
 Object.defineProperty(defaults, "__esModule", { value: true });
 defaults.assignDefaults = void 0;
-const codegen_1$r = codegen;
-const util_1$o = util;
+const codegen_1$v = codegen;
+const util_1$s = util;
 function assignDefaults(it, ty) {
     const { properties, items } = it.schema;
     if (ty === "object" && properties) {
@@ -1677,18 +1677,18 @@ function assignDefault(it, prop, defaultValue) {
     const { gen, compositeRule, data, opts } = it;
     if (defaultValue === undefined)
         return;
-    const childData = codegen_1$r._ `${data}${codegen_1$r.getProperty(prop)}`;
+    const childData = (0, codegen_1$v._) `${data}${(0, codegen_1$v.getProperty)(prop)}`;
     if (compositeRule) {
-        util_1$o.checkStrictMode(it, `default is ignored for: ${childData}`);
+        (0, util_1$s.checkStrictMode)(it, `default is ignored for: ${childData}`);
         return;
     }
-    let condition = codegen_1$r._ `${childData} === undefined`;
+    let condition = (0, codegen_1$v._) `${childData} === undefined`;
     if (opts.useDefaults === "empty") {
-        condition = codegen_1$r._ `${condition} || ${childData} === null || ${childData} === ""`;
+        condition = (0, codegen_1$v._) `${condition} || ${childData} === null || ${childData} === ""`;
     }
     // `${childData} === undefined` +
     // (opts.useDefaults === "empty" ? ` || ${childData} === null || ${childData} === ""` : "")
-    gen.if(condition, codegen_1$r._ `${childData} = ${codegen_1$r.stringify(defaultValue)}`);
+    gen.if(condition, (0, codegen_1$v._) `${childData} = ${(0, codegen_1$v.stringify)(defaultValue)}`);
 }
 
 var keyword = {};
@@ -1697,19 +1697,20 @@ var code = {};
 
 Object.defineProperty(code, "__esModule", { value: true });
 code.validateUnion = code.validateArray = code.usePattern = code.callValidateCode = code.schemaProperties = code.allSchemaProperties = code.noPropertyInData = code.propertyInData = code.isOwnProperty = code.hasPropFunc = code.reportMissingProp = code.checkMissingProp = code.checkReportMissingProp = void 0;
-const codegen_1$q = codegen;
-const util_1$n = util;
-const names_1$5 = names$1;
+const codegen_1$u = codegen;
+const util_1$r = util;
+const names_1$8 = names$1;
+const util_2$1 = util;
 function checkReportMissingProp(cxt, prop) {
     const { gen, data, it } = cxt;
     gen.if(noPropertyInData(gen, data, prop, it.opts.ownProperties), () => {
-        cxt.setParams({ missingProperty: codegen_1$q._ `${prop}` }, true);
+        cxt.setParams({ missingProperty: (0, codegen_1$u._) `${prop}` }, true);
         cxt.error();
     });
 }
 code.checkReportMissingProp = checkReportMissingProp;
 function checkMissingProp({ gen, data, it: { opts } }, properties, missing) {
-    return codegen_1$q.or(...properties.map((prop) => codegen_1$q.and(noPropertyInData(gen, data, prop, opts.ownProperties), codegen_1$q._ `${missing} = ${prop}`)));
+    return (0, codegen_1$u.or)(...properties.map((prop) => (0, codegen_1$u.and)(noPropertyInData(gen, data, prop, opts.ownProperties), (0, codegen_1$u._) `${missing} = ${prop}`)));
 }
 code.checkMissingProp = checkMissingProp;
 function reportMissingProp(cxt, missing) {
@@ -1721,22 +1722,22 @@ function hasPropFunc(gen) {
     return gen.scopeValue("func", {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         ref: Object.prototype.hasOwnProperty,
-        code: codegen_1$q._ `Object.prototype.hasOwnProperty`,
+        code: (0, codegen_1$u._) `Object.prototype.hasOwnProperty`,
     });
 }
 code.hasPropFunc = hasPropFunc;
 function isOwnProperty(gen, data, property) {
-    return codegen_1$q._ `${hasPropFunc(gen)}.call(${data}, ${property})`;
+    return (0, codegen_1$u._) `${hasPropFunc(gen)}.call(${data}, ${property})`;
 }
 code.isOwnProperty = isOwnProperty;
 function propertyInData(gen, data, property, ownProperties) {
-    const cond = codegen_1$q._ `${data}${codegen_1$q.getProperty(property)} !== undefined`;
-    return ownProperties ? codegen_1$q._ `${cond} && ${isOwnProperty(gen, data, property)}` : cond;
+    const cond = (0, codegen_1$u._) `${data}${(0, codegen_1$u.getProperty)(property)} !== undefined`;
+    return ownProperties ? (0, codegen_1$u._) `${cond} && ${isOwnProperty(gen, data, property)}` : cond;
 }
 code.propertyInData = propertyInData;
 function noPropertyInData(gen, data, property, ownProperties) {
-    const cond = codegen_1$q._ `${data}${codegen_1$q.getProperty(property)} === undefined`;
-    return ownProperties ? codegen_1$q.or(cond, codegen_1$q.not(isOwnProperty(gen, data, property))) : cond;
+    const cond = (0, codegen_1$u._) `${data}${(0, codegen_1$u.getProperty)(property)} === undefined`;
+    return ownProperties ? (0, codegen_1$u.or)(cond, (0, codegen_1$u.not)(isOwnProperty(gen, data, property))) : cond;
 }
 code.noPropertyInData = noPropertyInData;
 function allSchemaProperties(schemaMap) {
@@ -1744,29 +1745,31 @@ function allSchemaProperties(schemaMap) {
 }
 code.allSchemaProperties = allSchemaProperties;
 function schemaProperties(it, schemaMap) {
-    return allSchemaProperties(schemaMap).filter((p) => !util_1$n.alwaysValidSchema(it, schemaMap[p]));
+    return allSchemaProperties(schemaMap).filter((p) => !(0, util_1$r.alwaysValidSchema)(it, schemaMap[p]));
 }
 code.schemaProperties = schemaProperties;
 function callValidateCode({ schemaCode, data, it: { gen, topSchemaRef, schemaPath, errorPath }, it }, func, context, passSchema) {
-    const dataAndSchema = passSchema ? codegen_1$q._ `${schemaCode}, ${data}, ${topSchemaRef}${schemaPath}` : data;
+    const dataAndSchema = passSchema ? (0, codegen_1$u._) `${schemaCode}, ${data}, ${topSchemaRef}${schemaPath}` : data;
     const valCxt = [
-        [names_1$5.default.instancePath, codegen_1$q.strConcat(names_1$5.default.instancePath, errorPath)],
-        [names_1$5.default.parentData, it.parentData],
-        [names_1$5.default.parentDataProperty, it.parentDataProperty],
-        [names_1$5.default.rootData, names_1$5.default.rootData],
+        [names_1$8.default.instancePath, (0, codegen_1$u.strConcat)(names_1$8.default.instancePath, errorPath)],
+        [names_1$8.default.parentData, it.parentData],
+        [names_1$8.default.parentDataProperty, it.parentDataProperty],
+        [names_1$8.default.rootData, names_1$8.default.rootData],
     ];
     if (it.opts.dynamicRef)
-        valCxt.push([names_1$5.default.dynamicAnchors, names_1$5.default.dynamicAnchors]);
-    const args = codegen_1$q._ `${dataAndSchema}, ${gen.object(...valCxt)}`;
-    return context !== codegen_1$q.nil ? codegen_1$q._ `${func}.call(${context}, ${args})` : codegen_1$q._ `${func}(${args})`;
+        valCxt.push([names_1$8.default.dynamicAnchors, names_1$8.default.dynamicAnchors]);
+    const args = (0, codegen_1$u._) `${dataAndSchema}, ${gen.object(...valCxt)}`;
+    return context !== codegen_1$u.nil ? (0, codegen_1$u._) `${func}.call(${context}, ${args})` : (0, codegen_1$u._) `${func}(${args})`;
 }
 code.callValidateCode = callValidateCode;
+const newRegExp = (0, codegen_1$u._) `new RegExp`;
 function usePattern({ gen, it: { opts } }, pattern) {
     const u = opts.unicodeRegExp ? "u" : "";
+    const { regExp } = opts.code;
     return gen.scopeValue("pattern", {
         key: pattern,
-        ref: new RegExp(pattern, u),
-        code: codegen_1$q._ `new RegExp(${pattern}, ${u})`,
+        ref: regExp(pattern, u),
+        code: (0, codegen_1$u._) `${regExp.code === "new RegExp" ? newRegExp : (0, util_2$1.useFunc)(gen, regExp)}(${pattern}, ${u})`,
     });
 }
 code.usePattern = usePattern;
@@ -1782,14 +1785,14 @@ function validateArray(cxt) {
     validateItems(() => gen.break());
     return valid;
     function validateItems(notValid) {
-        const len = gen.const("len", codegen_1$q._ `${data}.length`);
+        const len = gen.const("len", (0, codegen_1$u._) `${data}.length`);
         gen.forRange("i", 0, len, (i) => {
             cxt.subschema({
                 keyword,
                 dataProp: i,
-                dataPropType: util_1$n.Type.Num,
+                dataPropType: util_1$r.Type.Num,
             }, valid);
-            gen.if(codegen_1$q.not(valid), notValid);
+            gen.if((0, codegen_1$u.not)(valid), notValid);
         });
     }
 }
@@ -1799,7 +1802,7 @@ function validateUnion(cxt) {
     /* istanbul ignore if */
     if (!Array.isArray(schema))
         throw new Error("ajv implementation error");
-    const alwaysValid = schema.some((sch) => util_1$n.alwaysValidSchema(it, sch));
+    const alwaysValid = schema.some((sch) => (0, util_1$r.alwaysValidSchema)(it, sch));
     if (alwaysValid && !it.opts.unevaluated)
         return;
     const valid = gen.let("valid", false);
@@ -1810,12 +1813,12 @@ function validateUnion(cxt) {
             schemaProp: i,
             compositeRule: true,
         }, schValid);
-        gen.assign(valid, codegen_1$q._ `${valid} || ${schValid}`);
+        gen.assign(valid, (0, codegen_1$u._) `${valid} || ${schValid}`);
         const merged = cxt.mergeValidEvaluated(schCxt, schValid);
         // can short-circuit if `unevaluatedProperties/Items` not supported (opts.unevaluated !== true)
         // or if all properties and items were evaluated (it.props === true && it.items === true)
         if (!merged)
-            gen.if(codegen_1$q.not(valid));
+            gen.if((0, codegen_1$u.not)(valid));
     }));
     cxt.result(valid, () => cxt.reset(), () => cxt.error(true));
 }
@@ -1823,8 +1826,8 @@ code.validateUnion = validateUnion;
 
 Object.defineProperty(keyword, "__esModule", { value: true });
 keyword.validateKeywordUsage = keyword.validSchemaType = keyword.funcKeywordCode = keyword.macroKeywordCode = void 0;
-const codegen_1$p = codegen;
-const names_1$4 = names$1;
+const codegen_1$t = codegen;
+const names_1$7 = names$1;
 const code_1$9 = code;
 const errors_1$1 = errors;
 function macroKeywordCode(cxt, def) {
@@ -1836,7 +1839,7 @@ function macroKeywordCode(cxt, def) {
     const valid = gen.name("valid");
     cxt.subschema({
         schema: macroSchema,
-        schemaPath: codegen_1$p.nil,
+        schemaPath: codegen_1$t.nil,
         errSchemaPath: `${it.errSchemaPath}/${keyword}`,
         topSchemaRef: schemaRef,
         compositeRule: true,
@@ -1869,37 +1872,37 @@ function funcKeywordCode(cxt, def) {
     }
     function validateAsync() {
         const ruleErrs = gen.let("ruleErrs", null);
-        gen.try(() => assignValid(codegen_1$p._ `await `), (e) => gen.assign(valid, false).if(codegen_1$p._ `${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, codegen_1$p._ `${e}.errors`), () => gen.throw(e)));
+        gen.try(() => assignValid((0, codegen_1$t._) `await `), (e) => gen.assign(valid, false).if((0, codegen_1$t._) `${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, (0, codegen_1$t._) `${e}.errors`), () => gen.throw(e)));
         return ruleErrs;
     }
     function validateSync() {
-        const validateErrs = codegen_1$p._ `${validateRef}.errors`;
+        const validateErrs = (0, codegen_1$t._) `${validateRef}.errors`;
         gen.assign(validateErrs, null);
-        assignValid(codegen_1$p.nil);
+        assignValid(codegen_1$t.nil);
         return validateErrs;
     }
-    function assignValid(_await = def.async ? codegen_1$p._ `await ` : codegen_1$p.nil) {
-        const passCxt = it.opts.passContext ? names_1$4.default.this : names_1$4.default.self;
+    function assignValid(_await = def.async ? (0, codegen_1$t._) `await ` : codegen_1$t.nil) {
+        const passCxt = it.opts.passContext ? names_1$7.default.this : names_1$7.default.self;
         const passSchema = !(("compile" in def && !$data) || def.schema === false);
-        gen.assign(valid, codegen_1$p._ `${_await}${code_1$9.callValidateCode(cxt, validateRef, passCxt, passSchema)}`, def.modifying);
+        gen.assign(valid, (0, codegen_1$t._) `${_await}${(0, code_1$9.callValidateCode)(cxt, validateRef, passCxt, passSchema)}`, def.modifying);
     }
     function reportErrs(errors) {
         var _a;
-        gen.if(codegen_1$p.not((_a = def.valid) !== null && _a !== void 0 ? _a : valid), errors);
+        gen.if((0, codegen_1$t.not)((_a = def.valid) !== null && _a !== void 0 ? _a : valid), errors);
     }
 }
 keyword.funcKeywordCode = funcKeywordCode;
 function modifyData(cxt) {
     const { gen, data, it } = cxt;
-    gen.if(it.parentData, () => gen.assign(data, codegen_1$p._ `${it.parentData}[${it.parentDataProperty}]`));
+    gen.if(it.parentData, () => gen.assign(data, (0, codegen_1$t._) `${it.parentData}[${it.parentDataProperty}]`));
 }
 function addErrs(cxt, errs) {
     const { gen } = cxt;
-    gen.if(codegen_1$p._ `Array.isArray(${errs})`, () => {
+    gen.if((0, codegen_1$t._) `Array.isArray(${errs})`, () => {
         gen
-            .assign(names_1$4.default.vErrors, codegen_1$p._ `${names_1$4.default.vErrors} === null ? ${errs} : ${names_1$4.default.vErrors}.concat(${errs})`)
-            .assign(names_1$4.default.errors, codegen_1$p._ `${names_1$4.default.vErrors}.length`);
-        errors_1$1.extendErrors(cxt);
+            .assign(names_1$7.default.vErrors, (0, codegen_1$t._) `${names_1$7.default.vErrors} === null ? ${errs} : ${names_1$7.default.vErrors}.concat(${errs})`)
+            .assign(names_1$7.default.errors, (0, codegen_1$t._) `${names_1$7.default.vErrors}.length`);
+        (0, errors_1$1.extendErrors)(cxt);
     }, () => cxt.error());
 }
 function checkAsyncKeyword({ schemaEnv }, def) {
@@ -1909,7 +1912,7 @@ function checkAsyncKeyword({ schemaEnv }, def) {
 function useKeyword(gen, keyword, result) {
     if (result === undefined)
         throw new Error(`keyword "${keyword}" failed to compile`);
-    return gen.scopeValue("keyword", typeof result == "function" ? { ref: result } : { ref: result, code: codegen_1$p.stringify(result) });
+    return gen.scopeValue("keyword", typeof result == "function" ? { ref: result } : { ref: result, code: (0, codegen_1$t.stringify)(result) });
 }
 function validSchemaType(schema, schemaType, allowUndefined = false) {
     // TODO add tests
@@ -1948,8 +1951,8 @@ var subschema = {};
 
 Object.defineProperty(subschema, "__esModule", { value: true });
 subschema.extendSubschemaMode = subschema.extendSubschemaData = subschema.getSubschema = void 0;
-const codegen_1$o = codegen;
-const util_1$m = util;
+const codegen_1$s = codegen;
+const util_1$q = util;
 function getSubschema(it, { keyword, schemaProp, schema, schemaPath, errSchemaPath, topSchemaRef }) {
     if (keyword !== undefined && schema !== undefined) {
         throw new Error('both "keyword" and "schema" passed, only one allowed');
@@ -1959,13 +1962,13 @@ function getSubschema(it, { keyword, schemaProp, schema, schemaPath, errSchemaPa
         return schemaProp === undefined
             ? {
                 schema: sch,
-                schemaPath: codegen_1$o._ `${it.schemaPath}${codegen_1$o.getProperty(keyword)}`,
+                schemaPath: (0, codegen_1$s._) `${it.schemaPath}${(0, codegen_1$s.getProperty)(keyword)}`,
                 errSchemaPath: `${it.errSchemaPath}/${keyword}`,
             }
             : {
                 schema: sch[schemaProp],
-                schemaPath: codegen_1$o._ `${it.schemaPath}${codegen_1$o.getProperty(keyword)}${codegen_1$o.getProperty(schemaProp)}`,
-                errSchemaPath: `${it.errSchemaPath}/${keyword}/${util_1$m.escapeFragment(schemaProp)}`,
+                schemaPath: (0, codegen_1$s._) `${it.schemaPath}${(0, codegen_1$s.getProperty)(keyword)}${(0, codegen_1$s.getProperty)(schemaProp)}`,
+                errSchemaPath: `${it.errSchemaPath}/${keyword}/${(0, util_1$q.escapeFragment)(schemaProp)}`,
             };
     }
     if (schema !== undefined) {
@@ -1989,14 +1992,14 @@ function extendSubschemaData(subschema, it, { dataProp, dataPropType: dpType, da
     const { gen } = it;
     if (dataProp !== undefined) {
         const { errorPath, dataPathArr, opts } = it;
-        const nextData = gen.let("data", codegen_1$o._ `${it.data}${codegen_1$o.getProperty(dataProp)}`, true);
+        const nextData = gen.let("data", (0, codegen_1$s._) `${it.data}${(0, codegen_1$s.getProperty)(dataProp)}`, true);
         dataContextProps(nextData);
-        subschema.errorPath = codegen_1$o.str `${errorPath}${util_1$m.getErrorPath(dataProp, dpType, opts.jsPropertySyntax)}`;
-        subschema.parentDataProperty = codegen_1$o._ `${dataProp}`;
+        subschema.errorPath = (0, codegen_1$s.str) `${errorPath}${(0, util_1$q.getErrorPath)(dataProp, dpType, opts.jsPropertySyntax)}`;
+        subschema.parentDataProperty = (0, codegen_1$s._) `${dataProp}`;
         subschema.dataPathArr = [...dataPathArr, subschema.parentDataProperty];
     }
     if (data !== undefined) {
-        const nextData = data instanceof codegen_1$o.Name ? data : gen.let("data", data, true); // replaceable if used once?
+        const nextData = data instanceof codegen_1$s.Name ? data : gen.let("data", data, true); // replaceable if used once?
         dataContextProps(nextData);
         if (propertyName !== undefined)
             subschema.propertyName = propertyName;
@@ -3577,7 +3580,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 Object.defineProperty(resolve$1, "__esModule", { value: true });
 resolve$1.getSchemaRefs = resolve$1.resolveUrl = resolve$1.normalizeId = resolve$1._getFullPath = resolve$1.getFullPath = resolve$1.inlineRef = void 0;
-const util_1$l = util;
+const util_1$p = util;
 const equal$2 = fastDeepEqual;
 const traverse = jsonSchemaTraverse.exports;
 const URI$1 = uri_all.exports;
@@ -3638,7 +3641,7 @@ function countKeys(schema) {
         if (SIMPLE_INLINED.has(key))
             continue;
         if (typeof schema[key] == "object") {
-            util_1$l.eachItem(schema[key], (sch) => (count += countKeys(sch)));
+            (0, util_1$p.eachItem)(schema[key], (sch) => (count += countKeys(sch)));
         }
         if (count === Infinity)
             return Infinity;
@@ -3667,11 +3670,11 @@ function resolveUrl(baseId, id) {
 }
 resolve$1.resolveUrl = resolveUrl;
 const ANCHOR = /^[a-z_][-a-z0-9._]*$/i;
-function getSchemaRefs(schema) {
+function getSchemaRefs(schema, baseId) {
     if (typeof schema == "boolean")
         return {};
     const { schemaId } = this.opts;
-    const schId = normalizeId(schema[schemaId]);
+    const schId = normalizeId(schema[schemaId] || baseId);
     const baseIds = { "": schId };
     const pathPrefix = getFullPath(schId, false);
     const localRefs = {};
@@ -3736,10 +3739,10 @@ const dataType_2 = dataType;
 const defaults_1 = defaults;
 const keyword_1 = keyword;
 const subschema_1 = subschema;
-const codegen_1$n = codegen;
-const names_1$3 = names$1;
+const codegen_1$r = codegen;
+const names_1$6 = names$1;
 const resolve_1$2 = resolve$1;
-const util_1$k = util;
+const util_1$o = util;
 const errors_1 = errors;
 // schema compilation - generates validation function, subschemaCode (below) is used for subschemas
 function validateFunctionCode(it) {
@@ -3750,39 +3753,39 @@ function validateFunctionCode(it) {
             return;
         }
     }
-    validateFunction(it, () => boolSchema_1.topBoolOrEmptySchema(it));
+    validateFunction(it, () => (0, boolSchema_1.topBoolOrEmptySchema)(it));
 }
 validate.validateFunctionCode = validateFunctionCode;
 function validateFunction({ gen, validateName, schema, schemaEnv, opts }, body) {
     if (opts.code.es5) {
-        gen.func(validateName, codegen_1$n._ `${names_1$3.default.data}, ${names_1$3.default.valCxt}`, schemaEnv.$async, () => {
-            gen.code(codegen_1$n._ `"use strict"; ${funcSourceUrl(schema, opts)}`);
+        gen.func(validateName, (0, codegen_1$r._) `${names_1$6.default.data}, ${names_1$6.default.valCxt}`, schemaEnv.$async, () => {
+            gen.code((0, codegen_1$r._) `"use strict"; ${funcSourceUrl(schema, opts)}`);
             destructureValCxtES5(gen, opts);
             gen.code(body);
         });
     }
     else {
-        gen.func(validateName, codegen_1$n._ `${names_1$3.default.data}, ${destructureValCxt(opts)}`, schemaEnv.$async, () => gen.code(funcSourceUrl(schema, opts)).code(body));
+        gen.func(validateName, (0, codegen_1$r._) `${names_1$6.default.data}, ${destructureValCxt(opts)}`, schemaEnv.$async, () => gen.code(funcSourceUrl(schema, opts)).code(body));
     }
 }
 function destructureValCxt(opts) {
-    return codegen_1$n._ `{${names_1$3.default.instancePath}="", ${names_1$3.default.parentData}, ${names_1$3.default.parentDataProperty}, ${names_1$3.default.rootData}=${names_1$3.default.data}${opts.dynamicRef ? codegen_1$n._ `, ${names_1$3.default.dynamicAnchors}={}` : codegen_1$n.nil}}={}`;
+    return (0, codegen_1$r._) `{${names_1$6.default.instancePath}="", ${names_1$6.default.parentData}, ${names_1$6.default.parentDataProperty}, ${names_1$6.default.rootData}=${names_1$6.default.data}${opts.dynamicRef ? (0, codegen_1$r._) `, ${names_1$6.default.dynamicAnchors}={}` : codegen_1$r.nil}}={}`;
 }
 function destructureValCxtES5(gen, opts) {
-    gen.if(names_1$3.default.valCxt, () => {
-        gen.var(names_1$3.default.instancePath, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.instancePath}`);
-        gen.var(names_1$3.default.parentData, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.parentData}`);
-        gen.var(names_1$3.default.parentDataProperty, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.parentDataProperty}`);
-        gen.var(names_1$3.default.rootData, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.rootData}`);
+    gen.if(names_1$6.default.valCxt, () => {
+        gen.var(names_1$6.default.instancePath, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.instancePath}`);
+        gen.var(names_1$6.default.parentData, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.parentData}`);
+        gen.var(names_1$6.default.parentDataProperty, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.parentDataProperty}`);
+        gen.var(names_1$6.default.rootData, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.rootData}`);
         if (opts.dynamicRef)
-            gen.var(names_1$3.default.dynamicAnchors, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.dynamicAnchors}`);
+            gen.var(names_1$6.default.dynamicAnchors, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.dynamicAnchors}`);
     }, () => {
-        gen.var(names_1$3.default.instancePath, codegen_1$n._ `""`);
-        gen.var(names_1$3.default.parentData, codegen_1$n._ `undefined`);
-        gen.var(names_1$3.default.parentDataProperty, codegen_1$n._ `undefined`);
-        gen.var(names_1$3.default.rootData, names_1$3.default.data);
+        gen.var(names_1$6.default.instancePath, (0, codegen_1$r._) `""`);
+        gen.var(names_1$6.default.parentData, (0, codegen_1$r._) `undefined`);
+        gen.var(names_1$6.default.parentDataProperty, (0, codegen_1$r._) `undefined`);
+        gen.var(names_1$6.default.rootData, names_1$6.default.data);
         if (opts.dynamicRef)
-            gen.var(names_1$3.default.dynamicAnchors, codegen_1$n._ `{}`);
+            gen.var(names_1$6.default.dynamicAnchors, (0, codegen_1$r._) `{}`);
     });
 }
 function topSchemaObjCode(it) {
@@ -3791,8 +3794,8 @@ function topSchemaObjCode(it) {
         if (opts.$comment && schema.$comment)
             commentKeyword(it);
         checkNoDefault(it);
-        gen.let(names_1$3.default.vErrors, null);
-        gen.let(names_1$3.default.errors, 0);
+        gen.let(names_1$6.default.vErrors, null);
+        gen.let(names_1$6.default.errors, 0);
         if (opts.unevaluated)
             resetEvaluated(it);
         typeAndKeywords(it);
@@ -3803,13 +3806,13 @@ function topSchemaObjCode(it) {
 function resetEvaluated(it) {
     // TODO maybe some hook to execute it in the end to check whether props/items are Name, as in assignEvaluated
     const { gen, validateName } = it;
-    it.evaluated = gen.const("evaluated", codegen_1$n._ `${validateName}.evaluated`);
-    gen.if(codegen_1$n._ `${it.evaluated}.dynamicProps`, () => gen.assign(codegen_1$n._ `${it.evaluated}.props`, codegen_1$n._ `undefined`));
-    gen.if(codegen_1$n._ `${it.evaluated}.dynamicItems`, () => gen.assign(codegen_1$n._ `${it.evaluated}.items`, codegen_1$n._ `undefined`));
+    it.evaluated = gen.const("evaluated", (0, codegen_1$r._) `${validateName}.evaluated`);
+    gen.if((0, codegen_1$r._) `${it.evaluated}.dynamicProps`, () => gen.assign((0, codegen_1$r._) `${it.evaluated}.props`, (0, codegen_1$r._) `undefined`));
+    gen.if((0, codegen_1$r._) `${it.evaluated}.dynamicItems`, () => gen.assign((0, codegen_1$r._) `${it.evaluated}.items`, (0, codegen_1$r._) `undefined`));
 }
 function funcSourceUrl(schema, opts) {
     const schId = typeof schema == "object" && schema[opts.schemaId];
-    return schId && (opts.code.source || opts.code.process) ? codegen_1$n._ `/*# sourceURL=${schId} */` : codegen_1$n.nil;
+    return schId && (opts.code.source || opts.code.process) ? (0, codegen_1$r._) `/*# sourceURL=${schId} */` : codegen_1$r.nil;
 }
 // schema compilation - this function is used recursively to generate code for sub-schemas
 function subschemaCode(it, valid) {
@@ -3820,7 +3823,7 @@ function subschemaCode(it, valid) {
             return;
         }
     }
-    boolSchema_1.boolOrEmptySchema(it, valid);
+    (0, boolSchema_1.boolOrEmptySchema)(it, valid);
 }
 function schemaCxtHasRules({ schema, self }) {
     if (typeof schema == "boolean")
@@ -3839,38 +3842,38 @@ function subSchemaObjCode(it, valid) {
         commentKeyword(it);
     updateContext(it);
     checkAsyncSchema(it);
-    const errsCount = gen.const("_errs", names_1$3.default.errors);
+    const errsCount = gen.const("_errs", names_1$6.default.errors);
     typeAndKeywords(it, errsCount);
     // TODO var
-    gen.var(valid, codegen_1$n._ `${errsCount} === ${names_1$3.default.errors}`);
+    gen.var(valid, (0, codegen_1$r._) `${errsCount} === ${names_1$6.default.errors}`);
 }
 function checkKeywords(it) {
-    util_1$k.checkUnknownRules(it);
+    (0, util_1$o.checkUnknownRules)(it);
     checkRefsAndKeywords(it);
 }
 function typeAndKeywords(it, errsCount) {
     if (it.opts.jtd)
         return schemaKeywords(it, [], false, errsCount);
-    const types = dataType_1$1.getSchemaTypes(it.schema);
-    const checkedTypes = dataType_1$1.coerceAndCheckDataType(it, types);
+    const types = (0, dataType_1$1.getSchemaTypes)(it.schema);
+    const checkedTypes = (0, dataType_1$1.coerceAndCheckDataType)(it, types);
     schemaKeywords(it, types, !checkedTypes, errsCount);
 }
 function checkRefsAndKeywords(it) {
     const { schema, errSchemaPath, opts, self } = it;
-    if (schema.$ref && opts.ignoreKeywordsWithRef && util_1$k.schemaHasRulesButRef(schema, self.RULES)) {
+    if (schema.$ref && opts.ignoreKeywordsWithRef && (0, util_1$o.schemaHasRulesButRef)(schema, self.RULES)) {
         self.logger.warn(`$ref: keywords ignored in schema at path "${errSchemaPath}"`);
     }
 }
 function checkNoDefault(it) {
     const { schema, opts } = it;
     if (schema.default !== undefined && opts.useDefaults && opts.strictSchema) {
-        util_1$k.checkStrictMode(it, "default is ignored in the schema root");
+        (0, util_1$o.checkStrictMode)(it, "default is ignored in the schema root");
     }
 }
 function updateContext(it) {
     const schId = it.schema[it.opts.schemaId];
     if (schId)
-        it.baseId = resolve_1$2.resolveUrl(it.baseId, schId);
+        it.baseId = (0, resolve_1$2.resolveUrl)(it.baseId, schId);
 }
 function checkAsyncSchema(it) {
     if (it.schema.$async && !it.schemaEnv.$async)
@@ -3879,37 +3882,37 @@ function checkAsyncSchema(it) {
 function commentKeyword({ gen, schemaEnv, schema, errSchemaPath, opts }) {
     const msg = schema.$comment;
     if (opts.$comment === true) {
-        gen.code(codegen_1$n._ `${names_1$3.default.self}.logger.log(${msg})`);
+        gen.code((0, codegen_1$r._) `${names_1$6.default.self}.logger.log(${msg})`);
     }
     else if (typeof opts.$comment == "function") {
-        const schemaPath = codegen_1$n.str `${errSchemaPath}/$comment`;
+        const schemaPath = (0, codegen_1$r.str) `${errSchemaPath}/$comment`;
         const rootName = gen.scopeValue("root", { ref: schemaEnv.root });
-        gen.code(codegen_1$n._ `${names_1$3.default.self}.opts.$comment(${msg}, ${schemaPath}, ${rootName}.schema)`);
+        gen.code((0, codegen_1$r._) `${names_1$6.default.self}.opts.$comment(${msg}, ${schemaPath}, ${rootName}.schema)`);
     }
 }
 function returnResults(it) {
     const { gen, schemaEnv, validateName, ValidationError, opts } = it;
     if (schemaEnv.$async) {
         // TODO assign unevaluated
-        gen.if(codegen_1$n._ `${names_1$3.default.errors} === 0`, () => gen.return(names_1$3.default.data), () => gen.throw(codegen_1$n._ `new ${ValidationError}(${names_1$3.default.vErrors})`));
+        gen.if((0, codegen_1$r._) `${names_1$6.default.errors} === 0`, () => gen.return(names_1$6.default.data), () => gen.throw((0, codegen_1$r._) `new ${ValidationError}(${names_1$6.default.vErrors})`));
     }
     else {
-        gen.assign(codegen_1$n._ `${validateName}.errors`, names_1$3.default.vErrors);
+        gen.assign((0, codegen_1$r._) `${validateName}.errors`, names_1$6.default.vErrors);
         if (opts.unevaluated)
             assignEvaluated(it);
-        gen.return(codegen_1$n._ `${names_1$3.default.errors} === 0`);
+        gen.return((0, codegen_1$r._) `${names_1$6.default.errors} === 0`);
     }
 }
 function assignEvaluated({ gen, evaluated, props, items }) {
-    if (props instanceof codegen_1$n.Name)
-        gen.assign(codegen_1$n._ `${evaluated}.props`, props);
-    if (items instanceof codegen_1$n.Name)
-        gen.assign(codegen_1$n._ `${evaluated}.items`, items);
+    if (props instanceof codegen_1$r.Name)
+        gen.assign((0, codegen_1$r._) `${evaluated}.props`, props);
+    if (items instanceof codegen_1$r.Name)
+        gen.assign((0, codegen_1$r._) `${evaluated}.items`, items);
 }
 function schemaKeywords(it, types, typeErrors, errsCount) {
     const { gen, schema, data, allErrors, opts, self } = it;
     const { RULES } = self;
-    if (schema.$ref && (opts.ignoreKeywordsWithRef || !util_1$k.schemaHasRulesButRef(schema, RULES))) {
+    if (schema.$ref && (opts.ignoreKeywordsWithRef || !(0, util_1$o.schemaHasRulesButRef)(schema, RULES))) {
         gen.block(() => keywordCode(it, "$ref", RULES.all.$ref.definition)); // TODO typecast
         return;
     }
@@ -3921,14 +3924,14 @@ function schemaKeywords(it, types, typeErrors, errsCount) {
         groupKeywords(RULES.post);
     });
     function groupKeywords(group) {
-        if (!applicability_1.shouldUseGroup(schema, group))
+        if (!(0, applicability_1.shouldUseGroup)(schema, group))
             return;
         if (group.type) {
-            gen.if(dataType_2.checkDataType(group.type, data, opts.strictNumbers));
+            gen.if((0, dataType_2.checkDataType)(group.type, data, opts.strictNumbers));
             iterateKeywords(it, group);
             if (types.length === 1 && types[0] === group.type && typeErrors) {
                 gen.else();
-                dataType_2.reportTypeError(it);
+                (0, dataType_2.reportTypeError)(it);
             }
             gen.endIf();
         }
@@ -3937,16 +3940,16 @@ function schemaKeywords(it, types, typeErrors, errsCount) {
         }
         // TODO make it "ok" call?
         if (!allErrors)
-            gen.if(codegen_1$n._ `${names_1$3.default.errors} === ${errsCount || 0}`);
+            gen.if((0, codegen_1$r._) `${names_1$6.default.errors} === ${errsCount || 0}`);
     }
 }
 function iterateKeywords(it, group) {
     const { gen, schema, opts: { useDefaults }, } = it;
     if (useDefaults)
-        defaults_1.assignDefaults(it, group.type);
+        (0, defaults_1.assignDefaults)(it, group.type);
     gen.block(() => {
         for (const rule of group.rules) {
-            if (applicability_1.shouldUseRule(schema, rule)) {
+            if ((0, applicability_1.shouldUseRule)(schema, rule)) {
                 keywordCode(it, rule.keyword, rule.definition, group.type);
             }
         }
@@ -3983,7 +3986,7 @@ function checkKeywordTypes(it, ts) {
     const rules = it.self.RULES.all;
     for (const keyword in rules) {
         const rule = rules[keyword];
-        if (typeof rule == "object" && applicability_1.shouldUseRule(it.schema, rule)) {
+        if (typeof rule == "object" && (0, applicability_1.shouldUseRule)(it.schema, rule)) {
             const { type } = rule.definition;
             if (type.length && !type.some((t) => hasApplicableType(ts, t))) {
                 strictTypesError(it, `missing type "${type.join(",")}" for keyword "${keyword}"`);
@@ -4000,18 +4003,18 @@ function includesType(ts, t) {
 function strictTypesError(it, msg) {
     const schemaPath = it.schemaEnv.baseId + it.errSchemaPath;
     msg += ` at "${schemaPath}" (strictTypes)`;
-    util_1$k.checkStrictMode(it, msg, it.opts.strictTypes);
+    (0, util_1$o.checkStrictMode)(it, msg, it.opts.strictTypes);
 }
 class KeywordCxt {
     constructor(it, def, keyword) {
-        keyword_1.validateKeywordUsage(it, def, keyword);
+        (0, keyword_1.validateKeywordUsage)(it, def, keyword);
         this.gen = it.gen;
         this.allErrors = it.allErrors;
         this.keyword = keyword;
         this.data = it.data;
         this.schema = it.schema[keyword];
         this.$data = def.$data && it.opts.$data && this.schema && this.schema.$data;
-        this.schemaValue = util_1$k.schemaRefOrVal(it, this.schema, keyword, this.$data);
+        this.schemaValue = (0, util_1$o.schemaRefOrVal)(it, this.schema, keyword, this.$data);
         this.schemaType = def.schemaType;
         this.parentSchema = it.schema;
         this.params = {};
@@ -4022,16 +4025,16 @@ class KeywordCxt {
         }
         else {
             this.schemaCode = this.schemaValue;
-            if (!keyword_1.validSchemaType(this.schema, def.schemaType, def.allowUndefined)) {
+            if (!(0, keyword_1.validSchemaType)(this.schema, def.schemaType, def.allowUndefined)) {
                 throw new Error(`${keyword} value must be ${JSON.stringify(def.schemaType)}`);
             }
         }
         if ("code" in def ? def.trackErrors : def.errors !== false) {
-            this.errsCount = it.gen.const("_errs", names_1$3.default.errors);
+            this.errsCount = it.gen.const("_errs", names_1$6.default.errors);
         }
     }
     result(condition, successAction, failAction) {
-        this.failResult(codegen_1$n.not(condition), successAction, failAction);
+        this.failResult((0, codegen_1$r.not)(condition), successAction, failAction);
     }
     failResult(condition, successAction, failAction) {
         this.gen.if(condition);
@@ -4053,7 +4056,7 @@ class KeywordCxt {
         }
     }
     pass(condition, failAction) {
-        this.failResult(codegen_1$n.not(condition), undefined, failAction);
+        this.failResult((0, codegen_1$r.not)(condition), undefined, failAction);
     }
     fail(condition) {
         if (condition === undefined) {
@@ -4073,7 +4076,7 @@ class KeywordCxt {
         if (!this.$data)
             return this.fail(condition);
         const { schemaCode } = this;
-        this.fail(codegen_1$n._ `${schemaCode} !== undefined && (${codegen_1$n.or(this.invalid$data(), condition)})`);
+        this.fail((0, codegen_1$r._) `${schemaCode} !== undefined && (${(0, codegen_1$r.or)(this.invalid$data(), condition)})`);
     }
     error(append, errorParams, errorPaths) {
         if (errorParams) {
@@ -4088,12 +4091,12 @@ class KeywordCxt {
         (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
     }
     $dataError() {
-        errors_1.reportError(this, this.def.$dataError || errors_1.keyword$DataError);
+        (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
     }
     reset() {
         if (this.errsCount === undefined)
             throw new Error('add "trackErrors" to keyword definition');
-        errors_1.resetErrorsCount(this.gen, this.errsCount);
+        (0, errors_1.resetErrorsCount)(this.gen, this.errsCount);
     }
     ok(cond) {
         if (!this.allErrors)
@@ -4105,52 +4108,52 @@ class KeywordCxt {
         else
             this.params = obj;
     }
-    block$data(valid, codeBlock, $dataValid = codegen_1$n.nil) {
+    block$data(valid, codeBlock, $dataValid = codegen_1$r.nil) {
         this.gen.block(() => {
             this.check$data(valid, $dataValid);
             codeBlock();
         });
     }
-    check$data(valid = codegen_1$n.nil, $dataValid = codegen_1$n.nil) {
+    check$data(valid = codegen_1$r.nil, $dataValid = codegen_1$r.nil) {
         if (!this.$data)
             return;
         const { gen, schemaCode, schemaType, def } = this;
-        gen.if(codegen_1$n.or(codegen_1$n._ `${schemaCode} === undefined`, $dataValid));
-        if (valid !== codegen_1$n.nil)
+        gen.if((0, codegen_1$r.or)((0, codegen_1$r._) `${schemaCode} === undefined`, $dataValid));
+        if (valid !== codegen_1$r.nil)
             gen.assign(valid, true);
         if (schemaType.length || def.validateSchema) {
             gen.elseIf(this.invalid$data());
             this.$dataError();
-            if (valid !== codegen_1$n.nil)
+            if (valid !== codegen_1$r.nil)
                 gen.assign(valid, false);
         }
         gen.else();
     }
     invalid$data() {
         const { gen, schemaCode, schemaType, def, it } = this;
-        return codegen_1$n.or(wrong$DataType(), invalid$DataSchema());
+        return (0, codegen_1$r.or)(wrong$DataType(), invalid$DataSchema());
         function wrong$DataType() {
             if (schemaType.length) {
                 /* istanbul ignore if */
-                if (!(schemaCode instanceof codegen_1$n.Name))
+                if (!(schemaCode instanceof codegen_1$r.Name))
                     throw new Error("ajv implementation error");
                 const st = Array.isArray(schemaType) ? schemaType : [schemaType];
-                return codegen_1$n._ `${dataType_2.checkDataTypes(st, schemaCode, it.opts.strictNumbers, dataType_2.DataType.Wrong)}`;
+                return (0, codegen_1$r._) `${(0, dataType_2.checkDataTypes)(st, schemaCode, it.opts.strictNumbers, dataType_2.DataType.Wrong)}`;
             }
-            return codegen_1$n.nil;
+            return codegen_1$r.nil;
         }
         function invalid$DataSchema() {
             if (def.validateSchema) {
                 const validateSchemaRef = gen.scopeValue("validate$data", { ref: def.validateSchema }); // TODO value.code for standalone
-                return codegen_1$n._ `!${validateSchemaRef}(${schemaCode})`;
+                return (0, codegen_1$r._) `!${validateSchemaRef}(${schemaCode})`;
             }
-            return codegen_1$n.nil;
+            return codegen_1$r.nil;
         }
     }
     subschema(appl, valid) {
-        const subschema = subschema_1.getSubschema(this.it, appl);
-        subschema_1.extendSubschemaData(subschema, this.it, appl);
-        subschema_1.extendSubschemaMode(subschema, appl);
+        const subschema = (0, subschema_1.getSubschema)(this.it, appl);
+        (0, subschema_1.extendSubschemaData)(subschema, this.it, appl);
+        (0, subschema_1.extendSubschemaMode)(subschema, appl);
         const nextContext = { ...this.it, ...subschema, items: undefined, props: undefined };
         subschemaCode(nextContext, valid);
         return nextContext;
@@ -4160,16 +4163,16 @@ class KeywordCxt {
         if (!it.opts.unevaluated)
             return;
         if (it.props !== true && schemaCxt.props !== undefined) {
-            it.props = util_1$k.mergeEvaluated.props(gen, schemaCxt.props, it.props, toName);
+            it.props = util_1$o.mergeEvaluated.props(gen, schemaCxt.props, it.props, toName);
         }
         if (it.items !== true && schemaCxt.items !== undefined) {
-            it.items = util_1$k.mergeEvaluated.items(gen, schemaCxt.items, it.items, toName);
+            it.items = util_1$o.mergeEvaluated.items(gen, schemaCxt.items, it.items, toName);
         }
     }
     mergeValidEvaluated(schemaCxt, valid) {
         const { it, gen } = this;
         if (it.opts.unevaluated && (it.props !== true || it.items !== true)) {
-            gen.if(valid, () => this.mergeEvaluated(schemaCxt, codegen_1$n.Name));
+            gen.if(valid, () => this.mergeEvaluated(schemaCxt, codegen_1$r.Name));
             return true;
         }
     }
@@ -4181,13 +4184,13 @@ function keywordCode(it, keyword, def, ruleType) {
         def.code(cxt, ruleType);
     }
     else if (cxt.$data && def.validate) {
-        keyword_1.funcKeywordCode(cxt, def);
+        (0, keyword_1.funcKeywordCode)(cxt, def);
     }
     else if ("macro" in def) {
-        keyword_1.macroKeywordCode(cxt, def);
+        (0, keyword_1.macroKeywordCode)(cxt, def);
     }
     else if (def.compile || def.validate) {
-        keyword_1.funcKeywordCode(cxt, def);
+        (0, keyword_1.funcKeywordCode)(cxt, def);
     }
 }
 const JSON_POINTER = /^\/(?:[^~]|~0|~1)*$/;
@@ -4196,12 +4199,12 @@ function getData($data, { dataLevel, dataNames, dataPathArr }) {
     let jsonPointer;
     let data;
     if ($data === "")
-        return names_1$3.default.rootData;
+        return names_1$6.default.rootData;
     if ($data[0] === "/") {
         if (!JSON_POINTER.test($data))
             throw new Error(`Invalid JSON-pointer: ${$data}`);
         jsonPointer = $data;
-        data = names_1$3.default.rootData;
+        data = names_1$6.default.rootData;
     }
     else {
         const matches = RELATIVE_JSON_POINTER.exec($data);
@@ -4224,8 +4227,8 @@ function getData($data, { dataLevel, dataNames, dataPathArr }) {
     const segments = jsonPointer.split("/");
     for (const segment of segments) {
         if (segment) {
-            data = codegen_1$n._ `${data}${codegen_1$n.getProperty(util_1$k.unescapeJsonPointer(segment))}`;
-            expr = codegen_1$n._ `${expr} && ${data}`;
+            data = (0, codegen_1$r._) `${data}${(0, codegen_1$r.getProperty)((0, util_1$o.unescapeJsonPointer)(segment))}`;
+            expr = (0, codegen_1$r._) `${expr} && ${data}`;
         }
     }
     return expr;
@@ -4254,8 +4257,8 @@ const resolve_1$1 = resolve$1;
 class MissingRefError extends Error {
     constructor(baseId, ref, msg) {
         super(msg || `can't resolve reference ${ref} from id ${baseId}`);
-        this.missingRef = resolve_1$1.resolveUrl(baseId, ref);
-        this.missingSchema = resolve_1$1.normalizeId(resolve_1$1.getFullPath(this.missingRef));
+        this.missingRef = (0, resolve_1$1.resolveUrl)(baseId, ref);
+        this.missingSchema = (0, resolve_1$1.normalizeId)((0, resolve_1$1.getFullPath)(this.missingRef));
     }
 }
 ref_error.default = MissingRefError;
@@ -4264,11 +4267,11 @@ var compile = {};
 
 Object.defineProperty(compile, "__esModule", { value: true });
 compile.resolveSchema = compile.getCompilingSchema = compile.resolveRef = compile.compileSchema = compile.SchemaEnv = void 0;
-const codegen_1$m = codegen;
+const codegen_1$q = codegen;
 const validation_error_1 = validation_error;
-const names_1$2 = names$1;
+const names_1$5 = names$1;
 const resolve_1 = resolve$1;
-const util_1$j = util;
+const util_1$n = util;
 const validate_1$1 = validate;
 const URI = uri_all.exports;
 class SchemaEnv {
@@ -4282,7 +4285,7 @@ class SchemaEnv {
         this.schema = env.schema;
         this.schemaId = env.schemaId;
         this.root = env.root || this;
-        this.baseId = (_a = env.baseId) !== null && _a !== void 0 ? _a : resolve_1.normalizeId(schema === null || schema === void 0 ? void 0 : schema[env.schemaId || "$id"]);
+        this.baseId = (_a = env.baseId) !== null && _a !== void 0 ? _a : (0, resolve_1.normalizeId)(schema === null || schema === void 0 ? void 0 : schema[env.schemaId || "$id"]);
         this.schemaPath = env.schemaPath;
         this.localRefs = env.localRefs;
         this.meta = env.meta;
@@ -4299,15 +4302,15 @@ function compileSchema(sch) {
     const _sch = getCompilingSchema.call(this, sch);
     if (_sch)
         return _sch;
-    const rootId = resolve_1.getFullPath(sch.root.baseId); // TODO if getFullPath removed 1 tests fails
+    const rootId = (0, resolve_1.getFullPath)(sch.root.baseId); // TODO if getFullPath removed 1 tests fails
     const { es5, lines } = this.opts.code;
     const { ownProperties } = this.opts;
-    const gen = new codegen_1$m.CodeGen(this.scope, { es5, lines, ownProperties });
+    const gen = new codegen_1$q.CodeGen(this.scope, { es5, lines, ownProperties });
     let _ValidationError;
     if (sch.$async) {
         _ValidationError = gen.scopeValue("Error", {
             ref: validation_error_1.default,
-            code: codegen_1$m._ `require("ajv/dist/runtime/validation_error").default`,
+            code: (0, codegen_1$q._) `require("ajv/dist/runtime/validation_error").default`,
         });
     }
     const validateName = gen.scopeName("validate");
@@ -4315,16 +4318,16 @@ function compileSchema(sch) {
     const schemaCxt = {
         gen,
         allErrors: this.opts.allErrors,
-        data: names_1$2.default.data,
-        parentData: names_1$2.default.parentData,
-        parentDataProperty: names_1$2.default.parentDataProperty,
-        dataNames: [names_1$2.default.data],
-        dataPathArr: [codegen_1$m.nil],
+        data: names_1$5.default.data,
+        parentData: names_1$5.default.parentData,
+        parentDataProperty: names_1$5.default.parentDataProperty,
+        dataNames: [names_1$5.default.data],
+        dataPathArr: [codegen_1$q.nil],
         dataLevel: 0,
         dataTypes: [],
         definedProperties: new Set(),
         topSchemaRef: gen.scopeValue("schema", this.opts.code.source === true
-            ? { ref: sch.schema, code: codegen_1$m.stringify(sch.schema) }
+            ? { ref: sch.schema, code: (0, codegen_1$q.stringify)(sch.schema) }
             : { ref: sch.schema }),
         validateName,
         ValidationError: _ValidationError,
@@ -4332,25 +4335,25 @@ function compileSchema(sch) {
         schemaEnv: sch,
         rootId,
         baseId: sch.baseId || rootId,
-        schemaPath: codegen_1$m.nil,
+        schemaPath: codegen_1$q.nil,
         errSchemaPath: sch.schemaPath || (this.opts.jtd ? "" : "#"),
-        errorPath: codegen_1$m._ `""`,
+        errorPath: (0, codegen_1$q._) `""`,
         opts: this.opts,
         self: this,
     };
     let sourceCode;
     try {
         this._compilations.add(sch);
-        validate_1$1.validateFunctionCode(schemaCxt);
+        (0, validate_1$1.validateFunctionCode)(schemaCxt);
         gen.optimize(this.opts.code.optimize);
         // gen.optimize(1)
         const validateCode = gen.toString();
-        sourceCode = `${gen.scopeRefs(names_1$2.default.scope)}return ${validateCode}`;
+        sourceCode = `${gen.scopeRefs(names_1$5.default.scope)}return ${validateCode}`;
         // console.log((codeSize += sourceCode.length), (nodeCount += gen.nodeCount))
         if (this.opts.code.process)
             sourceCode = this.opts.code.process(sourceCode, sch);
         // console.log("\n\n\n *** \n", sourceCode)
-        const makeValidate = new Function(`${names_1$2.default.self}`, `${names_1$2.default.scope}`, sourceCode);
+        const makeValidate = new Function(`${names_1$5.default.self}`, `${names_1$5.default.scope}`, sourceCode);
         const validate = makeValidate(this, this.scope.get());
         this.scope.value(validateName, { ref: validate });
         validate.errors = null;
@@ -4364,13 +4367,13 @@ function compileSchema(sch) {
         if (this.opts.unevaluated) {
             const { props, items } = schemaCxt;
             validate.evaluated = {
-                props: props instanceof codegen_1$m.Name ? undefined : props,
-                items: items instanceof codegen_1$m.Name ? undefined : items,
-                dynamicProps: props instanceof codegen_1$m.Name,
-                dynamicItems: items instanceof codegen_1$m.Name,
+                props: props instanceof codegen_1$q.Name ? undefined : props,
+                items: items instanceof codegen_1$q.Name ? undefined : items,
+                dynamicProps: props instanceof codegen_1$q.Name,
+                dynamicItems: items instanceof codegen_1$q.Name,
             };
             if (validate.source)
-                validate.source.evaluated = codegen_1$m.stringify(validate.evaluated);
+                validate.source.evaluated = (0, codegen_1$q.stringify)(validate.evaluated);
         }
         sch.validate = validate;
         return sch;
@@ -4390,7 +4393,7 @@ function compileSchema(sch) {
 compile.compileSchema = compileSchema;
 function resolveRef(root, baseId, ref) {
     var _a;
-    ref = resolve_1.resolveUrl(baseId, ref);
+    ref = (0, resolve_1.resolveUrl)(baseId, ref);
     const schOrFunc = root.refs[ref];
     if (schOrFunc)
         return schOrFunc;
@@ -4407,7 +4410,7 @@ function resolveRef(root, baseId, ref) {
 }
 compile.resolveRef = resolveRef;
 function inlineOrCompile(sch) {
-    if (resolve_1.inlineRef(sch.schema, this.opts.inlineRefs))
+    if ((0, resolve_1.inlineRef)(sch.schema, this.opts.inlineRefs))
         return sch.schema;
     return sch.validate ? sch : compileSchema.call(this, sch);
 }
@@ -4437,13 +4440,13 @@ function resolveSchema(root, // root object with properties schema, refs TODO be
 ref // reference to resolve
 ) {
     const p = URI.parse(ref);
-    const refPath = resolve_1._getFullPath(p);
-    let baseId = resolve_1.getFullPath(root.baseId);
+    const refPath = (0, resolve_1._getFullPath)(p);
+    let baseId = (0, resolve_1.getFullPath)(root.baseId);
     // TODO `Object.keys(root.schema).length > 0` should not be needed - but removing breaks 2 tests
     if (Object.keys(root.schema).length > 0 && refPath === baseId) {
         return getJsonPointer.call(this, p, root);
     }
-    const id = resolve_1.normalizeId(refPath);
+    const id = (0, resolve_1.normalizeId)(refPath);
     const schOrRef = this.refs[id] || this.schemas[id];
     if (typeof schOrRef == "string") {
         const sch = resolveSchema.call(this, root, schOrRef);
@@ -4455,12 +4458,12 @@ ref // reference to resolve
         return;
     if (!schOrRef.validate)
         compileSchema.call(this, schOrRef);
-    if (id === resolve_1.normalizeId(ref)) {
+    if (id === (0, resolve_1.normalizeId)(ref)) {
         const { schema } = schOrRef;
         const { schemaId } = this.opts;
         const schId = schema[schemaId];
         if (schId)
-            baseId = resolve_1.resolveUrl(baseId, schId);
+            baseId = (0, resolve_1.resolveUrl)(baseId, schId);
         return new SchemaEnv({ schema, schemaId, root, baseId });
     }
     return getJsonPointer.call(this, p, schOrRef);
@@ -4478,20 +4481,21 @@ function getJsonPointer(parsedRef, { baseId, schema, root }) {
     if (((_a = parsedRef.fragment) === null || _a === void 0 ? void 0 : _a[0]) !== "/")
         return;
     for (const part of parsedRef.fragment.slice(1).split("/")) {
-        if (typeof schema == "boolean")
+        if (typeof schema === "boolean")
             return;
-        schema = schema[util_1$j.unescapeFragment(part)];
-        if (schema === undefined)
+        const partSchema = schema[(0, util_1$n.unescapeFragment)(part)];
+        if (partSchema === undefined)
             return;
+        schema = partSchema;
         // TODO PREVENT_SCOPE_CHANGE could be defined in keyword def?
-        const schId = typeof schema == "object" && schema[this.opts.schemaId];
+        const schId = typeof schema === "object" && schema[this.opts.schemaId];
         if (!PREVENT_SCOPE_CHANGE.has(part) && schId) {
-            baseId = resolve_1.resolveUrl(baseId, schId);
+            baseId = (0, resolve_1.resolveUrl)(baseId, schId);
         }
     }
     let env;
-    if (typeof schema != "boolean" && schema.$ref && !util_1$j.schemaHasRulesButRef(schema, this.RULES)) {
-        const $ref = resolve_1.resolveUrl(baseId, schema.$ref);
+    if (typeof schema != "boolean" && schema.$ref && !(0, util_1$n.schemaHasRulesButRef)(schema, this.RULES)) {
+        const $ref = (0, resolve_1.resolveUrl)(baseId, schema.$ref);
         env = resolveSchema.call(this, root, $ref);
     }
     // even though resolution failed we need to return SchemaEnv to throw exception
@@ -4503,13 +4507,13 @@ function getJsonPointer(parsedRef, { baseId, schema, root }) {
     return undefined;
 }
 
-var $id$1 = "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#";
-var description$k = "Meta-schema for $data reference (JSON AnySchema extension proposal)";
-var type$j = "object";
+var $id$a = "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#";
+var description$l = "Meta-schema for $data reference (JSON AnySchema extension proposal)";
+var type$q = "object";
 var required$j = [
 	"$data"
 ];
-var properties$j = {
+var properties$q = {
 	$data: {
 		type: "string",
 		anyOf: [
@@ -4524,11 +4528,11 @@ var properties$j = {
 };
 var additionalProperties$i = false;
 var require$$9 = {
-	$id: $id$1,
-	description: description$k,
-	type: type$j,
+	$id: $id$a,
+	description: description$l,
+	type: type$q,
 	required: required$j,
-	properties: properties$j,
+	properties: properties$q,
 	additionalProperties: additionalProperties$i
 };
 
@@ -4553,6 +4557,8 @@ const resolve_1 = resolve$1;
 const dataType_1 = dataType;
 const util_1 = util;
 const $dataRefSchema = require$$9;
+const defaultRegExp = (str, flags) => new RegExp(str, flags);
+defaultRegExp.code = "new RegExp";
 const META_IGNORE_OPTIONS = ["removeAdditional", "useDefaults", "coerceTypes"];
 const EXT_SCOPE_NAMES = new Set([
     "validate",
@@ -4594,28 +4600,29 @@ const deprecatedOptions = {
 const MAX_EXPRESSION = 200;
 // eslint-disable-next-line complexity
 function requiredOptions(o) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z;
     const s = o.strict;
     const _optz = (_a = o.code) === null || _a === void 0 ? void 0 : _a.optimize;
     const optimize = _optz === true || _optz === undefined ? 1 : _optz || 0;
+    const regExp = (_c = (_b = o.code) === null || _b === void 0 ? void 0 : _b.regExp) !== null && _c !== void 0 ? _c : defaultRegExp;
     return {
-        strictSchema: (_c = (_b = o.strictSchema) !== null && _b !== void 0 ? _b : s) !== null && _c !== void 0 ? _c : true,
-        strictNumbers: (_e = (_d = o.strictNumbers) !== null && _d !== void 0 ? _d : s) !== null && _e !== void 0 ? _e : true,
-        strictTypes: (_g = (_f = o.strictTypes) !== null && _f !== void 0 ? _f : s) !== null && _g !== void 0 ? _g : "log",
-        strictTuples: (_j = (_h = o.strictTuples) !== null && _h !== void 0 ? _h : s) !== null && _j !== void 0 ? _j : "log",
-        strictRequired: (_l = (_k = o.strictRequired) !== null && _k !== void 0 ? _k : s) !== null && _l !== void 0 ? _l : false,
-        code: o.code ? { ...o.code, optimize } : { optimize },
-        loopRequired: (_m = o.loopRequired) !== null && _m !== void 0 ? _m : MAX_EXPRESSION,
-        loopEnum: (_o = o.loopEnum) !== null && _o !== void 0 ? _o : MAX_EXPRESSION,
-        meta: (_p = o.meta) !== null && _p !== void 0 ? _p : true,
-        messages: (_q = o.messages) !== null && _q !== void 0 ? _q : true,
-        inlineRefs: (_r = o.inlineRefs) !== null && _r !== void 0 ? _r : true,
-        schemaId: (_s = o.schemaId) !== null && _s !== void 0 ? _s : "$id",
-        addUsedSchema: (_t = o.addUsedSchema) !== null && _t !== void 0 ? _t : true,
-        validateSchema: (_u = o.validateSchema) !== null && _u !== void 0 ? _u : true,
-        validateFormats: (_v = o.validateFormats) !== null && _v !== void 0 ? _v : true,
-        unicodeRegExp: (_w = o.unicodeRegExp) !== null && _w !== void 0 ? _w : true,
-        int32range: (_x = o.int32range) !== null && _x !== void 0 ? _x : true,
+        strictSchema: (_e = (_d = o.strictSchema) !== null && _d !== void 0 ? _d : s) !== null && _e !== void 0 ? _e : true,
+        strictNumbers: (_g = (_f = o.strictNumbers) !== null && _f !== void 0 ? _f : s) !== null && _g !== void 0 ? _g : true,
+        strictTypes: (_j = (_h = o.strictTypes) !== null && _h !== void 0 ? _h : s) !== null && _j !== void 0 ? _j : "log",
+        strictTuples: (_l = (_k = o.strictTuples) !== null && _k !== void 0 ? _k : s) !== null && _l !== void 0 ? _l : "log",
+        strictRequired: (_o = (_m = o.strictRequired) !== null && _m !== void 0 ? _m : s) !== null && _o !== void 0 ? _o : false,
+        code: o.code ? { ...o.code, optimize, regExp } : { optimize, regExp },
+        loopRequired: (_p = o.loopRequired) !== null && _p !== void 0 ? _p : MAX_EXPRESSION,
+        loopEnum: (_q = o.loopEnum) !== null && _q !== void 0 ? _q : MAX_EXPRESSION,
+        meta: (_r = o.meta) !== null && _r !== void 0 ? _r : true,
+        messages: (_s = o.messages) !== null && _s !== void 0 ? _s : true,
+        inlineRefs: (_t = o.inlineRefs) !== null && _t !== void 0 ? _t : true,
+        schemaId: (_u = o.schemaId) !== null && _u !== void 0 ? _u : "$id",
+        addUsedSchema: (_v = o.addUsedSchema) !== null && _v !== void 0 ? _v : true,
+        validateSchema: (_w = o.validateSchema) !== null && _w !== void 0 ? _w : true,
+        validateFormats: (_x = o.validateFormats) !== null && _x !== void 0 ? _x : true,
+        unicodeRegExp: (_y = o.unicodeRegExp) !== null && _y !== void 0 ? _y : true,
+        int32range: (_z = o.int32range) !== null && _z !== void 0 ? _z : true,
     };
 }
 class Ajv {
@@ -4632,7 +4639,7 @@ class Ajv {
         this.logger = getLogger(opts.logger);
         const formatOpt = opts.validateFormats;
         opts.validateFormats = false;
-        this.RULES = rules_1.getRules();
+        this.RULES = (0, rules_1.getRules)();
         checkOptions.call(this, removedOptions, opts, "NOT SUPPORTED");
         checkOptions.call(this, deprecatedOptions, opts, "DEPRECATED", "warn");
         this._metaOpts = getMetaSchemaOptions.call(this);
@@ -4757,7 +4764,7 @@ class Ajv {
                 throw new Error(`schema ${schemaId} must be string`);
             }
         }
-        key = resolve_1.normalizeId(key || id);
+        key = (0, resolve_1.normalizeId)(key || id);
         this._checkUnique(key);
         this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true);
         return this;
@@ -4840,7 +4847,7 @@ class Ajv {
                 this._cache.delete(cacheKey);
                 let id = schemaKeyRef[this.opts.schemaId];
                 if (id) {
-                    id = resolve_1.normalizeId(id);
+                    id = (0, resolve_1.normalizeId)(id);
                     delete this.schemas[id];
                     delete this.refs[id];
                 }
@@ -4878,16 +4885,16 @@ class Ajv {
         }
         checkKeyword.call(this, keyword, def);
         if (!def) {
-            util_1.eachItem(keyword, (kwd) => addRule.call(this, kwd));
+            (0, util_1.eachItem)(keyword, (kwd) => addRule.call(this, kwd));
             return this;
         }
         keywordMetaschema.call(this, def);
         const definition = {
             ...def,
-            type: dataType_1.getJSONTypes(def.type),
-            schemaType: dataType_1.getJSONTypes(def.schemaType),
+            type: (0, dataType_1.getJSONTypes)(def.type),
+            schemaType: (0, dataType_1.getJSONTypes)(def.schemaType),
         };
-        util_1.eachItem(keyword, definition.type.length === 0
+        (0, util_1.eachItem)(keyword, definition.type.length === 0
             ? (k) => addRule.call(this, k, definition)
             : (k) => definition.type.forEach((t) => addRule.call(this, k, definition, t)));
         return this;
@@ -4974,8 +4981,8 @@ class Ajv {
         let sch = this._cache.get(schema);
         if (sch !== undefined)
             return sch;
-        const localRefs = resolve_1.getSchemaRefs.call(this, schema);
-        baseId = resolve_1.normalizeId(id || baseId);
+        baseId = (0, resolve_1.normalizeId)(id || baseId);
+        const localRefs = resolve_1.getSchemaRefs.call(this, schema, baseId);
         sch = new compile_1.SchemaEnv({ schema, schemaId, meta, baseId, localRefs });
         this._cache.set(sch.schema, sch);
         if (addSchema && !baseId.startsWith("#")) {
@@ -5025,7 +5032,7 @@ function checkOptions(checkOpts, options, msg, log = "error") {
     }
 }
 function getSchEnv(keyRef) {
-    keyRef = resolve_1.normalizeId(keyRef); // TODO tests fail without this line
+    keyRef = (0, resolve_1.normalizeId)(keyRef); // TODO tests fail without this line
     return this.schemas[keyRef] || this.refs[keyRef];
 }
 function addInitialSchemas() {
@@ -5077,7 +5084,7 @@ function getLogger(logger) {
 const KEYWORD_NAME = /^[a-z_$][a-z0-9_$:-]*$/i;
 function checkKeyword(keyword, def) {
     const { RULES } = this;
-    util_1.eachItem(keyword, (kwd) => {
+    (0, util_1.eachItem)(keyword, (kwd) => {
         if (RULES.keywords[kwd])
             throw new Error(`Keyword ${kwd} is already defined`);
         if (!KEYWORD_NAME.test(kwd))
@@ -5107,8 +5114,8 @@ function addRule(keyword, definition, dataType) {
         keyword,
         definition: {
             ...definition,
-            type: dataType_1.getJSONTypes(definition.type),
-            schemaType: dataType_1.getJSONTypes(definition.schemaType),
+            type: (0, dataType_1.getJSONTypes)(definition.type),
+            schemaType: (0, dataType_1.getJSONTypes)(definition.schemaType),
         },
     };
     if (definition.before)
@@ -5143,22 +5150,22 @@ function schemaOrData(schema) {
     return { anyOf: [schema, $dataRef] };
 }
 
-}(core$2));
+}(core$3));
 
-var draft7 = {};
+var draft2020 = {};
 
-var core$1 = {};
+var core$2 = {};
 
 var id = {};
 
 Object.defineProperty(id, "__esModule", { value: true });
-const def$s = {
+const def$B = {
     keyword: "id",
     code() {
         throw new Error('NOT SUPPORTED: keyword "id", use "$id" for schema ID');
     },
 };
-id.default = def$s;
+id.default = def$B;
 
 var ref = {};
 
@@ -5166,11 +5173,11 @@ Object.defineProperty(ref, "__esModule", { value: true });
 ref.callRef = ref.getValidate = void 0;
 const ref_error_1 = ref_error;
 const code_1$8 = code;
-const codegen_1$l = codegen;
-const names_1$1 = names$1;
-const compile_1 = compile;
-const util_1$i = util;
-const def$r = {
+const codegen_1$p = codegen;
+const names_1$4 = names$1;
+const compile_1$1 = compile;
+const util_1$m = util;
+const def$A = {
     keyword: "$ref",
     schemaType: "string",
     code(cxt) {
@@ -5179,29 +5186,29 @@ const def$r = {
         const { root } = env;
         if (($ref === "#" || $ref === "#/") && baseId === root.baseId)
             return callRootRef();
-        const schOrEnv = compile_1.resolveRef.call(self, root, baseId, $ref);
+        const schOrEnv = compile_1$1.resolveRef.call(self, root, baseId, $ref);
         if (schOrEnv === undefined)
             throw new ref_error_1.default(baseId, $ref);
-        if (schOrEnv instanceof compile_1.SchemaEnv)
+        if (schOrEnv instanceof compile_1$1.SchemaEnv)
             return callValidate(schOrEnv);
         return inlineRefSchema(schOrEnv);
         function callRootRef() {
             if (env === root)
                 return callRef(cxt, validateName, env, env.$async);
             const rootName = gen.scopeValue("root", { ref: root });
-            return callRef(cxt, codegen_1$l._ `${rootName}.validate`, root, root.$async);
+            return callRef(cxt, (0, codegen_1$p._) `${rootName}.validate`, root, root.$async);
         }
         function callValidate(sch) {
             const v = getValidate(cxt, sch);
             callRef(cxt, v, sch, sch.$async);
         }
         function inlineRefSchema(sch) {
-            const schName = gen.scopeValue("schema", opts.code.source === true ? { ref: sch, code: codegen_1$l.stringify(sch) } : { ref: sch });
+            const schName = gen.scopeValue("schema", opts.code.source === true ? { ref: sch, code: (0, codegen_1$p.stringify)(sch) } : { ref: sch });
             const valid = gen.name("valid");
             const schCxt = cxt.subschema({
                 schema: sch,
                 dataTypes: [],
-                schemaPath: codegen_1$l.nil,
+                schemaPath: codegen_1$p.nil,
                 topSchemaRef: schName,
                 errSchemaPath: $ref,
             }, valid);
@@ -5214,13 +5221,13 @@ function getValidate(cxt, sch) {
     const { gen } = cxt;
     return sch.validate
         ? gen.scopeValue("validate", { ref: sch.validate })
-        : codegen_1$l._ `${gen.scopeValue("wrapper", { ref: sch })}.validate`;
+        : (0, codegen_1$p._) `${gen.scopeValue("wrapper", { ref: sch })}.validate`;
 }
 ref.getValidate = getValidate;
 function callRef(cxt, v, sch, $async) {
     const { gen, it } = cxt;
     const { allErrors, schemaEnv: env, opts } = it;
-    const passCxt = opts.passContext ? names_1$1.default.this : codegen_1$l.nil;
+    const passCxt = opts.passContext ? names_1$4.default.this : codegen_1$p.nil;
     if ($async)
         callAsyncRef();
     else
@@ -5230,12 +5237,12 @@ function callRef(cxt, v, sch, $async) {
             throw new Error("async schema referenced by sync schema");
         const valid = gen.let("valid");
         gen.try(() => {
-            gen.code(codegen_1$l._ `await ${code_1$8.callValidateCode(cxt, v, passCxt)}`);
+            gen.code((0, codegen_1$p._) `await ${(0, code_1$8.callValidateCode)(cxt, v, passCxt)}`);
             addEvaluatedFrom(v); // TODO will not work with async, it has to be returned with the result
             if (!allErrors)
                 gen.assign(valid, true);
         }, (e) => {
-            gen.if(codegen_1$l._ `!(${e} instanceof ${it.ValidationError})`, () => gen.throw(e));
+            gen.if((0, codegen_1$p._) `!(${e} instanceof ${it.ValidationError})`, () => gen.throw(e));
             addErrorsFrom(e);
             if (!allErrors)
                 gen.assign(valid, false);
@@ -5243,12 +5250,12 @@ function callRef(cxt, v, sch, $async) {
         cxt.ok(valid);
     }
     function callSyncRef() {
-        cxt.result(code_1$8.callValidateCode(cxt, v, passCxt), () => addEvaluatedFrom(v), () => addErrorsFrom(v));
+        cxt.result((0, code_1$8.callValidateCode)(cxt, v, passCxt), () => addEvaluatedFrom(v), () => addErrorsFrom(v));
     }
     function addErrorsFrom(source) {
-        const errs = codegen_1$l._ `${source}.errors`;
-        gen.assign(names_1$1.default.vErrors, codegen_1$l._ `${names_1$1.default.vErrors} === null ? ${errs} : ${names_1$1.default.vErrors}.concat(${errs})`); // TODO tagged
-        gen.assign(names_1$1.default.errors, codegen_1$l._ `${names_1$1.default.vErrors}.length`);
+        const errs = (0, codegen_1$p._) `${source}.errors`;
+        gen.assign(names_1$4.default.vErrors, (0, codegen_1$p._) `${names_1$4.default.vErrors} === null ? ${errs} : ${names_1$4.default.vErrors}.concat(${errs})`); // TODO tagged
+        gen.assign(names_1$4.default.errors, (0, codegen_1$p._) `${names_1$4.default.vErrors}.length`);
     }
     function addEvaluatedFrom(source) {
         var _a;
@@ -5259,34 +5266,34 @@ function callRef(cxt, v, sch, $async) {
         if (it.props !== true) {
             if (schEvaluated && !schEvaluated.dynamicProps) {
                 if (schEvaluated.props !== undefined) {
-                    it.props = util_1$i.mergeEvaluated.props(gen, schEvaluated.props, it.props);
+                    it.props = util_1$m.mergeEvaluated.props(gen, schEvaluated.props, it.props);
                 }
             }
             else {
-                const props = gen.var("props", codegen_1$l._ `${source}.evaluated.props`);
-                it.props = util_1$i.mergeEvaluated.props(gen, props, it.props, codegen_1$l.Name);
+                const props = gen.var("props", (0, codegen_1$p._) `${source}.evaluated.props`);
+                it.props = util_1$m.mergeEvaluated.props(gen, props, it.props, codegen_1$p.Name);
             }
         }
         if (it.items !== true) {
             if (schEvaluated && !schEvaluated.dynamicItems) {
                 if (schEvaluated.items !== undefined) {
-                    it.items = util_1$i.mergeEvaluated.items(gen, schEvaluated.items, it.items);
+                    it.items = util_1$m.mergeEvaluated.items(gen, schEvaluated.items, it.items);
                 }
             }
             else {
-                const items = gen.var("items", codegen_1$l._ `${source}.evaluated.items`);
-                it.items = util_1$i.mergeEvaluated.items(gen, items, it.items, codegen_1$l.Name);
+                const items = gen.var("items", (0, codegen_1$p._) `${source}.evaluated.items`);
+                it.items = util_1$m.mergeEvaluated.items(gen, items, it.items, codegen_1$p.Name);
             }
         }
     }
 }
 ref.callRef = callRef;
-ref.default = def$r;
+ref.default = def$A;
 
-Object.defineProperty(core$1, "__esModule", { value: true });
+Object.defineProperty(core$2, "__esModule", { value: true });
 const id_1 = id;
-const ref_1 = ref;
-const core = [
+const ref_1$2 = ref;
+const core$1 = [
     "$schema",
     "$id",
     "$defs",
@@ -5294,66 +5301,66 @@ const core = [
     { keyword: "$comment" },
     "definitions",
     id_1.default,
-    ref_1.default,
+    ref_1$2.default,
 ];
-core$1.default = core;
+core$2.default = core$1;
 
-var validation$1 = {};
+var validation$2 = {};
 
 var limitNumber = {};
 
 Object.defineProperty(limitNumber, "__esModule", { value: true });
-const codegen_1$k = codegen;
-const ops = codegen_1$k.operators;
+const codegen_1$o = codegen;
+const ops = codegen_1$o.operators;
 const KWDs = {
     maximum: { okStr: "<=", ok: ops.LTE, fail: ops.GT },
     minimum: { okStr: ">=", ok: ops.GTE, fail: ops.LT },
     exclusiveMaximum: { okStr: "<", ok: ops.LT, fail: ops.GTE },
     exclusiveMinimum: { okStr: ">", ok: ops.GT, fail: ops.LTE },
 };
-const error$i = {
-    message: ({ keyword, schemaCode }) => codegen_1$k.str `must be ${KWDs[keyword].okStr} ${schemaCode}`,
-    params: ({ keyword, schemaCode }) => codegen_1$k._ `{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`,
+const error$k = {
+    message: ({ keyword, schemaCode }) => (0, codegen_1$o.str) `must be ${KWDs[keyword].okStr} ${schemaCode}`,
+    params: ({ keyword, schemaCode }) => (0, codegen_1$o._) `{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`,
 };
-const def$q = {
+const def$z = {
     keyword: Object.keys(KWDs),
     type: "number",
     schemaType: "number",
     $data: true,
-    error: error$i,
+    error: error$k,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        cxt.fail$data(codegen_1$k._ `${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
+        cxt.fail$data((0, codegen_1$o._) `${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
     },
 };
-limitNumber.default = def$q;
+limitNumber.default = def$z;
 
 var multipleOf = {};
 
 Object.defineProperty(multipleOf, "__esModule", { value: true });
-const codegen_1$j = codegen;
-const error$h = {
-    message: ({ schemaCode }) => codegen_1$j.str `must be multiple of ${schemaCode}`,
-    params: ({ schemaCode }) => codegen_1$j._ `{multipleOf: ${schemaCode}}`,
+const codegen_1$n = codegen;
+const error$j = {
+    message: ({ schemaCode }) => (0, codegen_1$n.str) `must be multiple of ${schemaCode}`,
+    params: ({ schemaCode }) => (0, codegen_1$n._) `{multipleOf: ${schemaCode}}`,
 };
-const def$p = {
+const def$y = {
     keyword: "multipleOf",
     type: "number",
     schemaType: "number",
     $data: true,
-    error: error$h,
+    error: error$j,
     code(cxt) {
         const { gen, data, schemaCode, it } = cxt;
         // const bdt = bad$DataType(schemaCode, <string>def.schemaType, $data)
         const prec = it.opts.multipleOfPrecision;
         const res = gen.let("res");
         const invalid = prec
-            ? codegen_1$j._ `Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}`
-            : codegen_1$j._ `${res} !== parseInt(${res})`;
-        cxt.fail$data(codegen_1$j._ `(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`);
+            ? (0, codegen_1$n._) `Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}`
+            : (0, codegen_1$n._) `${res} !== parseInt(${res})`;
+        cxt.fail$data((0, codegen_1$n._) `(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`);
     },
 };
-multipleOf.default = def$p;
+multipleOf.default = def$y;
 
 var limitLength = {};
 
@@ -5383,97 +5390,97 @@ ucs2length$1.default = ucs2length;
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default';
 
 Object.defineProperty(limitLength, "__esModule", { value: true });
-const codegen_1$i = codegen;
-const util_1$h = util;
+const codegen_1$m = codegen;
+const util_1$l = util;
 const ucs2length_1 = ucs2length$1;
-const error$g = {
+const error$i = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxLength" ? "more" : "fewer";
-        return codegen_1$i.str `must NOT have ${comp} than ${schemaCode} characters`;
+        return (0, codegen_1$m.str) `must NOT have ${comp} than ${schemaCode} characters`;
     },
-    params: ({ schemaCode }) => codegen_1$i._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$m._) `{limit: ${schemaCode}}`,
 };
-const def$o = {
+const def$x = {
     keyword: ["maxLength", "minLength"],
     type: "string",
     schemaType: "number",
     $data: true,
-    error: error$g,
+    error: error$i,
     code(cxt) {
         const { keyword, data, schemaCode, it } = cxt;
-        const op = keyword === "maxLength" ? codegen_1$i.operators.GT : codegen_1$i.operators.LT;
-        const len = it.opts.unicode === false ? codegen_1$i._ `${data}.length` : codegen_1$i._ `${util_1$h.useFunc(cxt.gen, ucs2length_1.default)}(${data})`;
-        cxt.fail$data(codegen_1$i._ `${len} ${op} ${schemaCode}`);
+        const op = keyword === "maxLength" ? codegen_1$m.operators.GT : codegen_1$m.operators.LT;
+        const len = it.opts.unicode === false ? (0, codegen_1$m._) `${data}.length` : (0, codegen_1$m._) `${(0, util_1$l.useFunc)(cxt.gen, ucs2length_1.default)}(${data})`;
+        cxt.fail$data((0, codegen_1$m._) `${len} ${op} ${schemaCode}`);
     },
 };
-limitLength.default = def$o;
+limitLength.default = def$x;
 
 var pattern = {};
 
 Object.defineProperty(pattern, "__esModule", { value: true });
 const code_1$7 = code;
-const codegen_1$h = codegen;
-const error$f = {
-    message: ({ schemaCode }) => codegen_1$h.str `must match pattern "${schemaCode}"`,
-    params: ({ schemaCode }) => codegen_1$h._ `{pattern: ${schemaCode}}`,
+const codegen_1$l = codegen;
+const error$h = {
+    message: ({ schemaCode }) => (0, codegen_1$l.str) `must match pattern "${schemaCode}"`,
+    params: ({ schemaCode }) => (0, codegen_1$l._) `{pattern: ${schemaCode}}`,
 };
-const def$n = {
+const def$w = {
     keyword: "pattern",
     type: "string",
     schemaType: "string",
     $data: true,
-    error: error$f,
+    error: error$h,
     code(cxt) {
         const { data, $data, schema, schemaCode, it } = cxt;
         // TODO regexp should be wrapped in try/catchs
         const u = it.opts.unicodeRegExp ? "u" : "";
-        const regExp = $data ? codegen_1$h._ `(new RegExp(${schemaCode}, ${u}))` : code_1$7.usePattern(cxt, schema);
-        cxt.fail$data(codegen_1$h._ `!${regExp}.test(${data})`);
+        const regExp = $data ? (0, codegen_1$l._) `(new RegExp(${schemaCode}, ${u}))` : (0, code_1$7.usePattern)(cxt, schema);
+        cxt.fail$data((0, codegen_1$l._) `!${regExp}.test(${data})`);
     },
 };
-pattern.default = def$n;
+pattern.default = def$w;
 
 var limitProperties = {};
 
 Object.defineProperty(limitProperties, "__esModule", { value: true });
-const codegen_1$g = codegen;
-const error$e = {
+const codegen_1$k = codegen;
+const error$g = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxProperties" ? "more" : "fewer";
-        return codegen_1$g.str `must NOT have ${comp} than ${schemaCode} items`;
+        return (0, codegen_1$k.str) `must NOT have ${comp} than ${schemaCode} items`;
     },
-    params: ({ schemaCode }) => codegen_1$g._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$k._) `{limit: ${schemaCode}}`,
 };
-const def$m = {
+const def$v = {
     keyword: ["maxProperties", "minProperties"],
     type: "object",
     schemaType: "number",
     $data: true,
-    error: error$e,
+    error: error$g,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        const op = keyword === "maxProperties" ? codegen_1$g.operators.GT : codegen_1$g.operators.LT;
-        cxt.fail$data(codegen_1$g._ `Object.keys(${data}).length ${op} ${schemaCode}`);
+        const op = keyword === "maxProperties" ? codegen_1$k.operators.GT : codegen_1$k.operators.LT;
+        cxt.fail$data((0, codegen_1$k._) `Object.keys(${data}).length ${op} ${schemaCode}`);
     },
 };
-limitProperties.default = def$m;
+limitProperties.default = def$v;
 
 var required$i = {};
 
 Object.defineProperty(required$i, "__esModule", { value: true });
 const code_1$6 = code;
-const codegen_1$f = codegen;
-const util_1$g = util;
-const error$d = {
-    message: ({ params: { missingProperty } }) => codegen_1$f.str `must have required property '${missingProperty}'`,
-    params: ({ params: { missingProperty } }) => codegen_1$f._ `{missingProperty: ${missingProperty}}`,
+const codegen_1$j = codegen;
+const util_1$k = util;
+const error$f = {
+    message: ({ params: { missingProperty } }) => (0, codegen_1$j.str) `must have required property '${missingProperty}'`,
+    params: ({ params: { missingProperty } }) => (0, codegen_1$j._) `{missingProperty: ${missingProperty}}`,
 };
-const def$l = {
+const def$u = {
     keyword: "required",
     type: "object",
     schemaType: "array",
     $data: true,
-    error: error$d,
+    error: error$f,
     code(cxt) {
         const { gen, schema, schemaCode, data, $data, it } = cxt;
         const { opts } = it;
@@ -5491,17 +5498,17 @@ const def$l = {
                 if ((props === null || props === void 0 ? void 0 : props[requiredKey]) === undefined && !definedProperties.has(requiredKey)) {
                     const schemaPath = it.schemaEnv.baseId + it.errSchemaPath;
                     const msg = `required property "${requiredKey}" is not defined at "${schemaPath}" (strictRequired)`;
-                    util_1$g.checkStrictMode(it, msg, it.opts.strictRequired);
+                    (0, util_1$k.checkStrictMode)(it, msg, it.opts.strictRequired);
                 }
             }
         }
         function allErrorsMode() {
             if (useLoop || $data) {
-                cxt.block$data(codegen_1$f.nil, loopAllRequired);
+                cxt.block$data(codegen_1$j.nil, loopAllRequired);
             }
             else {
                 for (const prop of schema) {
-                    code_1$6.checkReportMissingProp(cxt, prop);
+                    (0, code_1$6.checkReportMissingProp)(cxt, prop);
                 }
             }
         }
@@ -5513,55 +5520,55 @@ const def$l = {
                 cxt.ok(valid);
             }
             else {
-                gen.if(code_1$6.checkMissingProp(cxt, schema, missing));
-                code_1$6.reportMissingProp(cxt, missing);
+                gen.if((0, code_1$6.checkMissingProp)(cxt, schema, missing));
+                (0, code_1$6.reportMissingProp)(cxt, missing);
                 gen.else();
             }
         }
         function loopAllRequired() {
             gen.forOf("prop", schemaCode, (prop) => {
                 cxt.setParams({ missingProperty: prop });
-                gen.if(code_1$6.noPropertyInData(gen, data, prop, opts.ownProperties), () => cxt.error());
+                gen.if((0, code_1$6.noPropertyInData)(gen, data, prop, opts.ownProperties), () => cxt.error());
             });
         }
         function loopUntilMissing(missing, valid) {
             cxt.setParams({ missingProperty: missing });
             gen.forOf(missing, schemaCode, () => {
-                gen.assign(valid, code_1$6.propertyInData(gen, data, missing, opts.ownProperties));
-                gen.if(codegen_1$f.not(valid), () => {
+                gen.assign(valid, (0, code_1$6.propertyInData)(gen, data, missing, opts.ownProperties));
+                gen.if((0, codegen_1$j.not)(valid), () => {
                     cxt.error();
                     gen.break();
                 });
-            }, codegen_1$f.nil);
+            }, codegen_1$j.nil);
         }
     },
 };
-required$i.default = def$l;
+required$i.default = def$u;
 
 var limitItems = {};
 
 Object.defineProperty(limitItems, "__esModule", { value: true });
-const codegen_1$e = codegen;
-const error$c = {
+const codegen_1$i = codegen;
+const error$e = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxItems" ? "more" : "fewer";
-        return codegen_1$e.str `must NOT have ${comp} than ${schemaCode} items`;
+        return (0, codegen_1$i.str) `must NOT have ${comp} than ${schemaCode} items`;
     },
-    params: ({ schemaCode }) => codegen_1$e._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$i._) `{limit: ${schemaCode}}`,
 };
-const def$k = {
+const def$t = {
     keyword: ["maxItems", "minItems"],
     type: "array",
     schemaType: "number",
     $data: true,
-    error: error$c,
+    error: error$e,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        const op = keyword === "maxItems" ? codegen_1$e.operators.GT : codegen_1$e.operators.LT;
-        cxt.fail$data(codegen_1$e._ `${data}.length ${op} ${schemaCode}`);
+        const op = keyword === "maxItems" ? codegen_1$i.operators.GT : codegen_1$i.operators.LT;
+        cxt.fail$data((0, codegen_1$i._) `${data}.length ${op} ${schemaCode}`);
     },
 };
-limitItems.default = def$k;
+limitItems.default = def$t;
 
 var uniqueItems = {};
 
@@ -5575,114 +5582,114 @@ equal$1.default = equal;
 
 Object.defineProperty(uniqueItems, "__esModule", { value: true });
 const dataType_1 = dataType;
-const codegen_1$d = codegen;
-const util_1$f = util;
+const codegen_1$h = codegen;
+const util_1$j = util;
 const equal_1$2 = equal$1;
-const error$b = {
-    message: ({ params: { i, j } }) => codegen_1$d.str `must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
-    params: ({ params: { i, j } }) => codegen_1$d._ `{i: ${i}, j: ${j}}`,
+const error$d = {
+    message: ({ params: { i, j } }) => (0, codegen_1$h.str) `must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
+    params: ({ params: { i, j } }) => (0, codegen_1$h._) `{i: ${i}, j: ${j}}`,
 };
-const def$j = {
+const def$s = {
     keyword: "uniqueItems",
     type: "array",
     schemaType: "boolean",
     $data: true,
-    error: error$b,
+    error: error$d,
     code(cxt) {
         const { gen, data, $data, schema, parentSchema, schemaCode, it } = cxt;
         if (!$data && !schema)
             return;
         const valid = gen.let("valid");
-        const itemTypes = parentSchema.items ? dataType_1.getSchemaTypes(parentSchema.items) : [];
-        cxt.block$data(valid, validateUniqueItems, codegen_1$d._ `${schemaCode} === false`);
+        const itemTypes = parentSchema.items ? (0, dataType_1.getSchemaTypes)(parentSchema.items) : [];
+        cxt.block$data(valid, validateUniqueItems, (0, codegen_1$h._) `${schemaCode} === false`);
         cxt.ok(valid);
         function validateUniqueItems() {
-            const i = gen.let("i", codegen_1$d._ `${data}.length`);
+            const i = gen.let("i", (0, codegen_1$h._) `${data}.length`);
             const j = gen.let("j");
             cxt.setParams({ i, j });
             gen.assign(valid, true);
-            gen.if(codegen_1$d._ `${i} > 1`, () => (canOptimize() ? loopN : loopN2)(i, j));
+            gen.if((0, codegen_1$h._) `${i} > 1`, () => (canOptimize() ? loopN : loopN2)(i, j));
         }
         function canOptimize() {
             return itemTypes.length > 0 && !itemTypes.some((t) => t === "object" || t === "array");
         }
         function loopN(i, j) {
             const item = gen.name("item");
-            const wrongType = dataType_1.checkDataTypes(itemTypes, item, it.opts.strictNumbers, dataType_1.DataType.Wrong);
-            const indices = gen.const("indices", codegen_1$d._ `{}`);
-            gen.for(codegen_1$d._ `;${i}--;`, () => {
-                gen.let(item, codegen_1$d._ `${data}[${i}]`);
-                gen.if(wrongType, codegen_1$d._ `continue`);
+            const wrongType = (0, dataType_1.checkDataTypes)(itemTypes, item, it.opts.strictNumbers, dataType_1.DataType.Wrong);
+            const indices = gen.const("indices", (0, codegen_1$h._) `{}`);
+            gen.for((0, codegen_1$h._) `;${i}--;`, () => {
+                gen.let(item, (0, codegen_1$h._) `${data}[${i}]`);
+                gen.if(wrongType, (0, codegen_1$h._) `continue`);
                 if (itemTypes.length > 1)
-                    gen.if(codegen_1$d._ `typeof ${item} == "string"`, codegen_1$d._ `${item} += "_"`);
+                    gen.if((0, codegen_1$h._) `typeof ${item} == "string"`, (0, codegen_1$h._) `${item} += "_"`);
                 gen
-                    .if(codegen_1$d._ `typeof ${indices}[${item}] == "number"`, () => {
-                    gen.assign(j, codegen_1$d._ `${indices}[${item}]`);
+                    .if((0, codegen_1$h._) `typeof ${indices}[${item}] == "number"`, () => {
+                    gen.assign(j, (0, codegen_1$h._) `${indices}[${item}]`);
                     cxt.error();
                     gen.assign(valid, false).break();
                 })
-                    .code(codegen_1$d._ `${indices}[${item}] = ${i}`);
+                    .code((0, codegen_1$h._) `${indices}[${item}] = ${i}`);
             });
         }
         function loopN2(i, j) {
-            const eql = util_1$f.useFunc(gen, equal_1$2.default);
+            const eql = (0, util_1$j.useFunc)(gen, equal_1$2.default);
             const outer = gen.name("outer");
-            gen.label(outer).for(codegen_1$d._ `;${i}--;`, () => gen.for(codegen_1$d._ `${j} = ${i}; ${j}--;`, () => gen.if(codegen_1$d._ `${eql}(${data}[${i}], ${data}[${j}])`, () => {
+            gen.label(outer).for((0, codegen_1$h._) `;${i}--;`, () => gen.for((0, codegen_1$h._) `${j} = ${i}; ${j}--;`, () => gen.if((0, codegen_1$h._) `${eql}(${data}[${i}], ${data}[${j}])`, () => {
                 cxt.error();
                 gen.assign(valid, false).break(outer);
             })));
         }
     },
 };
-uniqueItems.default = def$j;
+uniqueItems.default = def$s;
 
 var _const = {};
 
 Object.defineProperty(_const, "__esModule", { value: true });
-const codegen_1$c = codegen;
-const util_1$e = util;
+const codegen_1$g = codegen;
+const util_1$i = util;
 const equal_1$1 = equal$1;
-const error$a = {
+const error$c = {
     message: "must be equal to constant",
-    params: ({ schemaCode }) => codegen_1$c._ `{allowedValue: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$g._) `{allowedValue: ${schemaCode}}`,
 };
-const def$i = {
+const def$r = {
     keyword: "const",
     $data: true,
-    error: error$a,
+    error: error$c,
     code(cxt) {
         const { gen, data, $data, schemaCode, schema } = cxt;
         if ($data || (schema && typeof schema == "object")) {
-            cxt.fail$data(codegen_1$c._ `!${util_1$e.useFunc(gen, equal_1$1.default)}(${data}, ${schemaCode})`);
+            cxt.fail$data((0, codegen_1$g._) `!${(0, util_1$i.useFunc)(gen, equal_1$1.default)}(${data}, ${schemaCode})`);
         }
         else {
-            cxt.fail(codegen_1$c._ `${schema} !== ${data}`);
+            cxt.fail((0, codegen_1$g._) `${schema} !== ${data}`);
         }
     },
 };
-_const.default = def$i;
+_const.default = def$r;
 
 var _enum = {};
 
 Object.defineProperty(_enum, "__esModule", { value: true });
-const codegen_1$b = codegen;
-const util_1$d = util;
+const codegen_1$f = codegen;
+const util_1$h = util;
 const equal_1 = equal$1;
-const error$9 = {
+const error$b = {
     message: "must be equal to one of the allowed values",
-    params: ({ schemaCode }) => codegen_1$b._ `{allowedValues: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$f._) `{allowedValues: ${schemaCode}}`,
 };
-const def$h = {
+const def$q = {
     keyword: "enum",
     schemaType: "array",
     $data: true,
-    error: error$9,
+    error: error$b,
     code(cxt) {
         const { gen, data, $data, schema, schemaCode, it } = cxt;
         if (!$data && schema.length === 0)
             throw new Error("enum must have non-empty array");
         const useLoop = schema.length >= it.opts.loopEnum;
-        const eql = util_1$d.useFunc(gen, equal_1.default);
+        const eql = (0, util_1$h.useFunc)(gen, equal_1.default);
         let valid;
         if (useLoop || $data) {
             valid = gen.let("valid");
@@ -5693,24 +5700,24 @@ const def$h = {
             if (!Array.isArray(schema))
                 throw new Error("ajv implementation error");
             const vSchema = gen.const("vSchema", schemaCode);
-            valid = codegen_1$b.or(...schema.map((_x, i) => equalCode(vSchema, i)));
+            valid = (0, codegen_1$f.or)(...schema.map((_x, i) => equalCode(vSchema, i)));
         }
         cxt.pass(valid);
         function loopEnum() {
             gen.assign(valid, false);
-            gen.forOf("v", schemaCode, (v) => gen.if(codegen_1$b._ `${eql}(${data}, ${v})`, () => gen.assign(valid, true).break()));
+            gen.forOf("v", schemaCode, (v) => gen.if((0, codegen_1$f._) `${eql}(${data}, ${v})`, () => gen.assign(valid, true).break()));
         }
         function equalCode(vSchema, i) {
             const sch = schema[i];
             return typeof sch === "object" && sch !== null
-                ? codegen_1$b._ `${eql}(${data}, ${vSchema}[${i}])`
-                : codegen_1$b._ `${data} === ${sch}`;
+                ? (0, codegen_1$f._) `${eql}(${data}, ${vSchema}[${i}])`
+                : (0, codegen_1$f._) `${data} === ${sch}`;
         }
     },
 };
-_enum.default = def$h;
+_enum.default = def$q;
 
-Object.defineProperty(validation$1, "__esModule", { value: true });
+Object.defineProperty(validation$2, "__esModule", { value: true });
 const limitNumber_1 = limitNumber;
 const multipleOf_1 = multipleOf;
 const limitLength_1 = limitLength;
@@ -5721,7 +5728,7 @@ const limitItems_1 = limitItems;
 const uniqueItems_1 = uniqueItems;
 const const_1 = _const;
 const enum_1 = _enum;
-const validation = [
+const validation$1 = [
     // number
     limitNumber_1.default,
     multipleOf_1.default,
@@ -5740,31 +5747,31 @@ const validation = [
     const_1.default,
     enum_1.default,
 ];
-validation$1.default = validation;
+validation$2.default = validation$1;
 
-var applicator = {};
+var applicator$1 = {};
 
 var additionalItems = {};
 
 Object.defineProperty(additionalItems, "__esModule", { value: true });
 additionalItems.validateAdditionalItems = void 0;
-const codegen_1$a = codegen;
-const util_1$c = util;
-const error$8 = {
-    message: ({ params: { len } }) => codegen_1$a.str `must NOT have more than ${len} items`,
-    params: ({ params: { len } }) => codegen_1$a._ `{limit: ${len}}`,
+const codegen_1$e = codegen;
+const util_1$g = util;
+const error$a = {
+    message: ({ params: { len } }) => (0, codegen_1$e.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$e._) `{limit: ${len}}`,
 };
-const def$g = {
+const def$p = {
     keyword: "additionalItems",
     type: "array",
     schemaType: ["boolean", "object"],
     before: "uniqueItems",
-    error: error$8,
+    error: error$a,
     code(cxt) {
         const { parentSchema, it } = cxt;
         const { items } = parentSchema;
         if (!Array.isArray(items)) {
-            util_1$c.checkStrictMode(it, '"additionalItems" is ignored when "items" is not an array of schemas');
+            (0, util_1$g.checkStrictMode)(it, '"additionalItems" is ignored when "items" is not an array of schemas');
             return;
         }
         validateAdditionalItems(cxt, items);
@@ -5773,26 +5780,26 @@ const def$g = {
 function validateAdditionalItems(cxt, items) {
     const { gen, schema, data, keyword, it } = cxt;
     it.items = true;
-    const len = gen.const("len", codegen_1$a._ `${data}.length`);
+    const len = gen.const("len", (0, codegen_1$e._) `${data}.length`);
     if (schema === false) {
         cxt.setParams({ len: items.length });
-        cxt.pass(codegen_1$a._ `${len} <= ${items.length}`);
+        cxt.pass((0, codegen_1$e._) `${len} <= ${items.length}`);
     }
-    else if (typeof schema == "object" && !util_1$c.alwaysValidSchema(it, schema)) {
-        const valid = gen.var("valid", codegen_1$a._ `${len} <= ${items.length}`); // TODO var
-        gen.if(codegen_1$a.not(valid), () => validateItems(valid));
+    else if (typeof schema == "object" && !(0, util_1$g.alwaysValidSchema)(it, schema)) {
+        const valid = gen.var("valid", (0, codegen_1$e._) `${len} <= ${items.length}`); // TODO var
+        gen.if((0, codegen_1$e.not)(valid), () => validateItems(valid));
         cxt.ok(valid);
     }
     function validateItems(valid) {
         gen.forRange("i", items.length, len, (i) => {
-            cxt.subschema({ keyword, dataProp: i, dataPropType: util_1$c.Type.Num }, valid);
+            cxt.subschema({ keyword, dataProp: i, dataPropType: util_1$g.Type.Num }, valid);
             if (!it.allErrors)
-                gen.if(codegen_1$a.not(valid), () => gen.break());
+                gen.if((0, codegen_1$e.not)(valid), () => gen.break());
         });
     }
 }
 additionalItems.validateAdditionalItems = validateAdditionalItems;
-additionalItems.default = def$g;
+additionalItems.default = def$p;
 
 var prefixItems = {};
 
@@ -5800,10 +5807,10 @@ var items = {};
 
 Object.defineProperty(items, "__esModule", { value: true });
 items.validateTuple = void 0;
-const codegen_1$9 = codegen;
-const util_1$b = util;
+const codegen_1$d = codegen;
+const util_1$f = util;
 const code_1$5 = code;
-const def$f = {
+const def$o = {
     keyword: "items",
     type: "array",
     schemaType: ["object", "array", "boolean"],
@@ -5813,23 +5820,23 @@ const def$f = {
         if (Array.isArray(schema))
             return validateTuple(cxt, "additionalItems", schema);
         it.items = true;
-        if (util_1$b.alwaysValidSchema(it, schema))
+        if ((0, util_1$f.alwaysValidSchema)(it, schema))
             return;
-        cxt.ok(code_1$5.validateArray(cxt));
+        cxt.ok((0, code_1$5.validateArray)(cxt));
     },
 };
 function validateTuple(cxt, extraItems, schArr = cxt.schema) {
     const { gen, parentSchema, data, keyword, it } = cxt;
     checkStrictTuple(parentSchema);
     if (it.opts.unevaluated && schArr.length && it.items !== true) {
-        it.items = util_1$b.mergeEvaluated.items(gen, schArr.length, it.items);
+        it.items = util_1$f.mergeEvaluated.items(gen, schArr.length, it.items);
     }
     const valid = gen.name("valid");
-    const len = gen.const("len", codegen_1$9._ `${data}.length`);
+    const len = gen.const("len", (0, codegen_1$d._) `${data}.length`);
     schArr.forEach((sch, i) => {
-        if (util_1$b.alwaysValidSchema(it, sch))
+        if ((0, util_1$f.alwaysValidSchema)(it, sch))
             return;
-        gen.if(codegen_1$9._ `${len} > ${i}`, () => cxt.subschema({
+        gen.if((0, codegen_1$d._) `${len} > ${i}`, () => cxt.subschema({
             keyword,
             schemaProp: i,
             dataProp: i,
@@ -5842,73 +5849,73 @@ function validateTuple(cxt, extraItems, schArr = cxt.schema) {
         const fullTuple = l === sch.minItems && (l === sch.maxItems || sch[extraItems] === false);
         if (opts.strictTuples && !fullTuple) {
             const msg = `"${keyword}" is ${l}-tuple, but minItems or maxItems/${extraItems} are not specified or different at path "${errSchemaPath}"`;
-            util_1$b.checkStrictMode(it, msg, opts.strictTuples);
+            (0, util_1$f.checkStrictMode)(it, msg, opts.strictTuples);
         }
     }
 }
 items.validateTuple = validateTuple;
-items.default = def$f;
+items.default = def$o;
 
 Object.defineProperty(prefixItems, "__esModule", { value: true });
 const items_1$1 = items;
-const def$e = {
+const def$n = {
     keyword: "prefixItems",
     type: "array",
     schemaType: ["array"],
     before: "uniqueItems",
-    code: (cxt) => items_1$1.validateTuple(cxt, "items"),
+    code: (cxt) => (0, items_1$1.validateTuple)(cxt, "items"),
 };
-prefixItems.default = def$e;
+prefixItems.default = def$n;
 
 var items2020 = {};
 
 Object.defineProperty(items2020, "__esModule", { value: true });
-const codegen_1$8 = codegen;
-const util_1$a = util;
+const codegen_1$c = codegen;
+const util_1$e = util;
 const code_1$4 = code;
 const additionalItems_1$1 = additionalItems;
-const error$7 = {
-    message: ({ params: { len } }) => codegen_1$8.str `must NOT have more than ${len} items`,
-    params: ({ params: { len } }) => codegen_1$8._ `{limit: ${len}}`,
+const error$9 = {
+    message: ({ params: { len } }) => (0, codegen_1$c.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$c._) `{limit: ${len}}`,
 };
-const def$d = {
+const def$m = {
     keyword: "items",
     type: "array",
     schemaType: ["object", "boolean"],
     before: "uniqueItems",
-    error: error$7,
+    error: error$9,
     code(cxt) {
         const { schema, parentSchema, it } = cxt;
         const { prefixItems } = parentSchema;
         it.items = true;
-        if (util_1$a.alwaysValidSchema(it, schema))
+        if ((0, util_1$e.alwaysValidSchema)(it, schema))
             return;
         if (prefixItems)
-            additionalItems_1$1.validateAdditionalItems(cxt, prefixItems);
+            (0, additionalItems_1$1.validateAdditionalItems)(cxt, prefixItems);
         else
-            cxt.ok(code_1$4.validateArray(cxt));
+            cxt.ok((0, code_1$4.validateArray)(cxt));
     },
 };
-items2020.default = def$d;
+items2020.default = def$m;
 
 var contains = {};
 
 Object.defineProperty(contains, "__esModule", { value: true });
-const codegen_1$7 = codegen;
-const util_1$9 = util;
-const error$6 = {
+const codegen_1$b = codegen;
+const util_1$d = util;
+const error$8 = {
     message: ({ params: { min, max } }) => max === undefined
-        ? codegen_1$7.str `must contain at least ${min} valid item(s)`
-        : codegen_1$7.str `must contain at least ${min} and no more than ${max} valid item(s)`,
-    params: ({ params: { min, max } }) => max === undefined ? codegen_1$7._ `{minContains: ${min}}` : codegen_1$7._ `{minContains: ${min}, maxContains: ${max}}`,
+        ? (0, codegen_1$b.str) `must contain at least ${min} valid item(s)`
+        : (0, codegen_1$b.str) `must contain at least ${min} and no more than ${max} valid item(s)`,
+    params: ({ params: { min, max } }) => max === undefined ? (0, codegen_1$b._) `{minContains: ${min}}` : (0, codegen_1$b._) `{minContains: ${min}, maxContains: ${max}}`,
 };
-const def$c = {
+const def$l = {
     keyword: "contains",
     type: "array",
     schemaType: ["object", "boolean"],
     before: "uniqueItems",
     trackErrors: true,
-    error: error$6,
+    error: error$8,
     code(cxt) {
         const { gen, schema, parentSchema, data, it } = cxt;
         let min;
@@ -5921,21 +5928,21 @@ const def$c = {
         else {
             min = 1;
         }
-        const len = gen.const("len", codegen_1$7._ `${data}.length`);
+        const len = gen.const("len", (0, codegen_1$b._) `${data}.length`);
         cxt.setParams({ min, max });
         if (max === undefined && min === 0) {
-            util_1$9.checkStrictMode(it, `"minContains" == 0 without "maxContains": "contains" keyword ignored`);
+            (0, util_1$d.checkStrictMode)(it, `"minContains" == 0 without "maxContains": "contains" keyword ignored`);
             return;
         }
         if (max !== undefined && min > max) {
-            util_1$9.checkStrictMode(it, `"minContains" > "maxContains" is always invalid`);
+            (0, util_1$d.checkStrictMode)(it, `"minContains" > "maxContains" is always invalid`);
             cxt.fail();
             return;
         }
-        if (util_1$9.alwaysValidSchema(it, schema)) {
-            let cond = codegen_1$7._ `${len} >= ${min}`;
+        if ((0, util_1$d.alwaysValidSchema)(it, schema)) {
+            let cond = (0, codegen_1$b._) `${len} >= ${min}`;
             if (max !== undefined)
-                cond = codegen_1$7._ `${cond} && ${len} <= ${max}`;
+                cond = (0, codegen_1$b._) `${cond} && ${len} <= ${max}`;
             cxt.pass(cond);
             return;
         }
@@ -5944,40 +5951,48 @@ const def$c = {
         if (max === undefined && min === 1) {
             validateItems(valid, () => gen.if(valid, () => gen.break()));
         }
+        else if (min === 0) {
+            gen.let(valid, true);
+            if (max !== undefined)
+                gen.if((0, codegen_1$b._) `${data}.length > 0`, validateItemsWithCount);
+        }
         else {
             gen.let(valid, false);
+            validateItemsWithCount();
+        }
+        cxt.result(valid, () => cxt.reset());
+        function validateItemsWithCount() {
             const schValid = gen.name("_valid");
             const count = gen.let("count", 0);
             validateItems(schValid, () => gen.if(schValid, () => checkLimits(count)));
         }
-        cxt.result(valid, () => cxt.reset());
         function validateItems(_valid, block) {
             gen.forRange("i", 0, len, (i) => {
                 cxt.subschema({
                     keyword: "contains",
                     dataProp: i,
-                    dataPropType: util_1$9.Type.Num,
+                    dataPropType: util_1$d.Type.Num,
                     compositeRule: true,
                 }, _valid);
                 block();
             });
         }
         function checkLimits(count) {
-            gen.code(codegen_1$7._ `${count}++`);
+            gen.code((0, codegen_1$b._) `${count}++`);
             if (max === undefined) {
-                gen.if(codegen_1$7._ `${count} >= ${min}`, () => gen.assign(valid, true).break());
+                gen.if((0, codegen_1$b._) `${count} >= ${min}`, () => gen.assign(valid, true).break());
             }
             else {
-                gen.if(codegen_1$7._ `${count} > ${max}`, () => gen.assign(valid, false).break());
+                gen.if((0, codegen_1$b._) `${count} > ${max}`, () => gen.assign(valid, false).break());
                 if (min === 1)
                     gen.assign(valid, true);
                 else
-                    gen.if(codegen_1$7._ `${count} >= ${min}`, () => gen.assign(valid, true));
+                    gen.if((0, codegen_1$b._) `${count} >= ${min}`, () => gen.assign(valid, true));
             }
         }
     },
 };
-contains.default = def$c;
+contains.default = def$l;
 
 var dependencies = {};
 
@@ -5990,9 +6005,9 @@ const code_1 = code;
 exports.error = {
     message: ({ params: { property, depsCount, deps } }) => {
         const property_ies = depsCount === 1 ? "property" : "properties";
-        return codegen_1.str `must have ${property_ies} ${deps} when property ${property} is present`;
+        return (0, codegen_1.str) `must have ${property_ies} ${deps} when property ${property} is present`;
     },
-    params: ({ params: { property, depsCount, deps, missingProperty } }) => codegen_1._ `{property: ${property},
+    params: ({ params: { property, depsCount, deps, missingProperty } }) => (0, codegen_1._) `{property: ${property},
     missingProperty: ${missingProperty},
     depsCount: ${depsCount},
     deps: ${deps}}`, // TODO change to reference
@@ -6028,7 +6043,7 @@ function validatePropertyDeps(cxt, propertyDeps = cxt.schema) {
         const deps = propertyDeps[prop];
         if (deps.length === 0)
             continue;
-        const hasProperty = code_1.propertyInData(gen, data, prop, it.opts.ownProperties);
+        const hasProperty = (0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties);
         cxt.setParams({
             property: prop,
             depsCount: deps.length,
@@ -6037,13 +6052,13 @@ function validatePropertyDeps(cxt, propertyDeps = cxt.schema) {
         if (it.allErrors) {
             gen.if(hasProperty, () => {
                 for (const depProp of deps) {
-                    code_1.checkReportMissingProp(cxt, depProp);
+                    (0, code_1.checkReportMissingProp)(cxt, depProp);
                 }
             });
         }
         else {
-            gen.if(codegen_1._ `${hasProperty} && (${code_1.checkMissingProp(cxt, deps, missing)})`);
-            code_1.reportMissingProp(cxt, missing);
+            gen.if((0, codegen_1._) `${hasProperty} && (${(0, code_1.checkMissingProp)(cxt, deps, missing)})`);
+            (0, code_1.reportMissingProp)(cxt, missing);
             gen.else();
         }
     }
@@ -6053,9 +6068,9 @@ function validateSchemaDeps(cxt, schemaDeps = cxt.schema) {
     const { gen, data, keyword, it } = cxt;
     const valid = gen.name("valid");
     for (const prop in schemaDeps) {
-        if (util_1.alwaysValidSchema(it, schemaDeps[prop]))
+        if ((0, util_1.alwaysValidSchema)(it, schemaDeps[prop]))
             continue;
-        gen.if(code_1.propertyInData(gen, data, prop, it.opts.ownProperties), () => {
+        gen.if((0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties), () => {
             const schCxt = cxt.subschema({ keyword, schemaProp: prop }, valid);
             cxt.mergeValidEvaluated(schCxt, valid);
         }, () => gen.var(valid, true) // TODO var
@@ -6071,20 +6086,20 @@ exports.default = def;
 var propertyNames = {};
 
 Object.defineProperty(propertyNames, "__esModule", { value: true });
-const codegen_1$6 = codegen;
-const util_1$8 = util;
-const error$5 = {
+const codegen_1$a = codegen;
+const util_1$c = util;
+const error$7 = {
     message: "property name must be valid",
-    params: ({ params }) => codegen_1$6._ `{propertyName: ${params.propertyName}}`,
+    params: ({ params }) => (0, codegen_1$a._) `{propertyName: ${params.propertyName}}`,
 };
-const def$b = {
+const def$k = {
     keyword: "propertyNames",
     type: "object",
     schemaType: ["object", "boolean"],
-    error: error$5,
+    error: error$7,
     code(cxt) {
         const { gen, schema, data, it } = cxt;
-        if (util_1$8.alwaysValidSchema(it, schema))
+        if ((0, util_1$c.alwaysValidSchema)(it, schema))
             return;
         const valid = gen.name("valid");
         gen.forIn("key", data, (key) => {
@@ -6096,7 +6111,7 @@ const def$b = {
                 propertyName: key,
                 compositeRule: true,
             }, valid);
-            gen.if(codegen_1$6.not(valid), () => {
+            gen.if((0, codegen_1$a.not)(valid), () => {
                 cxt.error(true);
                 if (!it.allErrors)
                     gen.break();
@@ -6105,26 +6120,26 @@ const def$b = {
         cxt.ok(valid);
     },
 };
-propertyNames.default = def$b;
+propertyNames.default = def$k;
 
 var additionalProperties$h = {};
 
 Object.defineProperty(additionalProperties$h, "__esModule", { value: true });
 const code_1$3 = code;
-const codegen_1$5 = codegen;
-const names_1 = names$1;
-const util_1$7 = util;
-const error$4 = {
+const codegen_1$9 = codegen;
+const names_1$3 = names$1;
+const util_1$b = util;
+const error$6 = {
     message: "must NOT have additional properties",
-    params: ({ params }) => codegen_1$5._ `{additionalProperty: ${params.additionalProperty}}`,
+    params: ({ params }) => (0, codegen_1$9._) `{additionalProperty: ${params.additionalProperty}}`,
 };
-const def$a = {
+const def$j = {
     keyword: "additionalProperties",
     type: ["object"],
     schemaType: ["boolean", "object"],
     allowUndefined: true,
     trackErrors: true,
-    error: error$4,
+    error: error$6,
     code(cxt) {
         const { gen, schema, parentSchema, data, errsCount, it } = cxt;
         /* istanbul ignore if */
@@ -6132,12 +6147,12 @@ const def$a = {
             throw new Error("ajv implementation error");
         const { allErrors, opts } = it;
         it.props = true;
-        if (opts.removeAdditional !== "all" && util_1$7.alwaysValidSchema(it, schema))
+        if (opts.removeAdditional !== "all" && (0, util_1$b.alwaysValidSchema)(it, schema))
             return;
-        const props = code_1$3.allSchemaProperties(parentSchema.properties);
-        const patProps = code_1$3.allSchemaProperties(parentSchema.patternProperties);
+        const props = (0, code_1$3.allSchemaProperties)(parentSchema.properties);
+        const patProps = (0, code_1$3.allSchemaProperties)(parentSchema.patternProperties);
         checkAdditionalProperties();
-        cxt.ok(codegen_1$5._ `${errsCount} === ${names_1.default.errors}`);
+        cxt.ok((0, codegen_1$9._) `${errsCount} === ${names_1$3.default.errors}`);
         function checkAdditionalProperties() {
             gen.forIn("key", data, (key) => {
                 if (!props.length && !patProps.length)
@@ -6150,22 +6165,22 @@ const def$a = {
             let definedProp;
             if (props.length > 8) {
                 // TODO maybe an option instead of hard-coded 8?
-                const propsSchema = util_1$7.schemaRefOrVal(it, parentSchema.properties, "properties");
-                definedProp = code_1$3.isOwnProperty(gen, propsSchema, key);
+                const propsSchema = (0, util_1$b.schemaRefOrVal)(it, parentSchema.properties, "properties");
+                definedProp = (0, code_1$3.isOwnProperty)(gen, propsSchema, key);
             }
             else if (props.length) {
-                definedProp = codegen_1$5.or(...props.map((p) => codegen_1$5._ `${key} === ${p}`));
+                definedProp = (0, codegen_1$9.or)(...props.map((p) => (0, codegen_1$9._) `${key} === ${p}`));
             }
             else {
-                definedProp = codegen_1$5.nil;
+                definedProp = codegen_1$9.nil;
             }
             if (patProps.length) {
-                definedProp = codegen_1$5.or(definedProp, ...patProps.map((p) => codegen_1$5._ `${code_1$3.usePattern(cxt, p)}.test(${key})`));
+                definedProp = (0, codegen_1$9.or)(definedProp, ...patProps.map((p) => (0, codegen_1$9._) `${(0, code_1$3.usePattern)(cxt, p)}.test(${key})`));
             }
-            return codegen_1$5.not(definedProp);
+            return (0, codegen_1$9.not)(definedProp);
         }
         function deleteAdditional(key) {
-            gen.code(codegen_1$5._ `delete ${data}[${key}]`);
+            gen.code((0, codegen_1$9._) `delete ${data}[${key}]`);
         }
         function additionalPropertyCode(key) {
             if (opts.removeAdditional === "all" || (opts.removeAdditional && schema === false)) {
@@ -6179,11 +6194,11 @@ const def$a = {
                     gen.break();
                 return;
             }
-            if (typeof schema == "object" && !util_1$7.alwaysValidSchema(it, schema)) {
+            if (typeof schema == "object" && !(0, util_1$b.alwaysValidSchema)(it, schema)) {
                 const valid = gen.name("valid");
                 if (opts.removeAdditional === "failing") {
                     applyAdditionalSchema(key, valid, false);
-                    gen.if(codegen_1$5.not(valid), () => {
+                    gen.if((0, codegen_1$9.not)(valid), () => {
                         cxt.reset();
                         deleteAdditional(key);
                     });
@@ -6191,7 +6206,7 @@ const def$a = {
                 else {
                     applyAdditionalSchema(key, valid);
                     if (!allErrors)
-                        gen.if(codegen_1$5.not(valid), () => gen.break());
+                        gen.if((0, codegen_1$9.not)(valid), () => gen.break());
                 }
             }
         }
@@ -6199,7 +6214,7 @@ const def$a = {
             const subschema = {
                 keyword: "additionalProperties",
                 dataProp: key,
-                dataPropType: util_1$7.Type.Str,
+                dataPropType: util_1$b.Type.Str,
             };
             if (errors === false) {
                 Object.assign(subschema, {
@@ -6212,16 +6227,16 @@ const def$a = {
         }
     },
 };
-additionalProperties$h.default = def$a;
+additionalProperties$h.default = def$j;
 
-var properties$i = {};
+var properties$p = {};
 
-Object.defineProperty(properties$i, "__esModule", { value: true });
+Object.defineProperty(properties$p, "__esModule", { value: true });
 const validate_1 = validate;
 const code_1$2 = code;
-const util_1$6 = util;
+const util_1$a = util;
 const additionalProperties_1$1 = additionalProperties$h;
-const def$9 = {
+const def$i = {
     keyword: "properties",
     type: "object",
     schemaType: "object",
@@ -6230,14 +6245,14 @@ const def$9 = {
         if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
             additionalProperties_1$1.default.code(new validate_1.KeywordCxt(it, additionalProperties_1$1.default, "additionalProperties"));
         }
-        const allProps = code_1$2.allSchemaProperties(schema);
+        const allProps = (0, code_1$2.allSchemaProperties)(schema);
         for (const prop of allProps) {
             it.definedProperties.add(prop);
         }
         if (it.opts.unevaluated && allProps.length && it.props !== true) {
-            it.props = util_1$6.mergeEvaluated.props(gen, util_1$6.toHash(allProps), it.props);
+            it.props = util_1$a.mergeEvaluated.props(gen, (0, util_1$a.toHash)(allProps), it.props);
         }
-        const properties = allProps.filter((p) => !util_1$6.alwaysValidSchema(it, schema[p]));
+        const properties = allProps.filter((p) => !(0, util_1$a.alwaysValidSchema)(it, schema[p]));
         if (properties.length === 0)
             return;
         const valid = gen.name("valid");
@@ -6246,7 +6261,7 @@ const def$9 = {
                 applyPropertySchema(prop);
             }
             else {
-                gen.if(code_1$2.propertyInData(gen, data, prop, it.opts.ownProperties));
+                gen.if((0, code_1$2.propertyInData)(gen, data, prop, it.opts.ownProperties));
                 applyPropertySchema(prop);
                 if (!it.allErrors)
                     gen.else().var(valid, true);
@@ -6267,24 +6282,24 @@ const def$9 = {
         }
     },
 };
-properties$i.default = def$9;
+properties$p.default = def$i;
 
 var patternProperties = {};
 
 Object.defineProperty(patternProperties, "__esModule", { value: true });
 const code_1$1 = code;
-const codegen_1$4 = codegen;
-const util_1$5 = util;
+const codegen_1$8 = codegen;
+const util_1$9 = util;
 const util_2 = util;
-const def$8 = {
+const def$h = {
     keyword: "patternProperties",
     type: "object",
     schemaType: "object",
     code(cxt) {
         const { gen, schema, data, parentSchema, it } = cxt;
         const { opts } = it;
-        const patterns = code_1$1.allSchemaProperties(schema);
-        const alwaysValidPatterns = patterns.filter((p) => util_1$5.alwaysValidSchema(it, schema[p]));
+        const patterns = (0, code_1$1.allSchemaProperties)(schema);
+        const alwaysValidPatterns = patterns.filter((p) => (0, util_1$9.alwaysValidSchema)(it, schema[p]));
         if (patterns.length === 0 ||
             (alwaysValidPatterns.length === patterns.length &&
                 (!it.opts.unevaluated || it.props === true))) {
@@ -6292,8 +6307,8 @@ const def$8 = {
         }
         const checkProperties = opts.strictSchema && !opts.allowMatchingProperties && parentSchema.properties;
         const valid = gen.name("valid");
-        if (it.props !== true && !(it.props instanceof codegen_1$4.Name)) {
-            it.props = util_2.evaluatedPropsToName(gen, it.props);
+        if (it.props !== true && !(it.props instanceof codegen_1$8.Name)) {
+            it.props = (0, util_2.evaluatedPropsToName)(gen, it.props);
         }
         const { props } = it;
         validatePatternProperties();
@@ -6314,13 +6329,13 @@ const def$8 = {
         function checkMatchingProperties(pat) {
             for (const prop in checkProperties) {
                 if (new RegExp(pat).test(prop)) {
-                    util_1$5.checkStrictMode(it, `property ${prop} matches pattern ${pat} (use allowMatchingProperties)`);
+                    (0, util_1$9.checkStrictMode)(it, `property ${prop} matches pattern ${pat} (use allowMatchingProperties)`);
                 }
             }
         }
         function validateProperties(pat) {
             gen.forIn("key", data, (key) => {
-                gen.if(codegen_1$4._ `${code_1$1.usePattern(cxt, pat)}.test(${key})`, () => {
+                gen.if((0, codegen_1$8._) `${(0, code_1$1.usePattern)(cxt, pat)}.test(${key})`, () => {
                     const alwaysValid = alwaysValidPatterns.includes(pat);
                     if (!alwaysValid) {
                         cxt.subschema({
@@ -6331,31 +6346,31 @@ const def$8 = {
                         }, valid);
                     }
                     if (it.opts.unevaluated && props !== true) {
-                        gen.assign(codegen_1$4._ `${props}[${key}]`, true);
+                        gen.assign((0, codegen_1$8._) `${props}[${key}]`, true);
                     }
                     else if (!alwaysValid && !it.allErrors) {
                         // can short-circuit if `unevaluatedProperties` is not supported (opts.next === false)
                         // or if all properties were evaluated (props === true)
-                        gen.if(codegen_1$4.not(valid), () => gen.break());
+                        gen.if((0, codegen_1$8.not)(valid), () => gen.break());
                     }
                 });
             });
         }
     },
 };
-patternProperties.default = def$8;
+patternProperties.default = def$h;
 
 var not = {};
 
 Object.defineProperty(not, "__esModule", { value: true });
-const util_1$4 = util;
-const def$7 = {
+const util_1$8 = util;
+const def$g = {
     keyword: "not",
     schemaType: ["object", "boolean"],
     trackErrors: true,
     code(cxt) {
         const { gen, schema, it } = cxt;
-        if (util_1$4.alwaysValidSchema(it, schema)) {
+        if ((0, util_1$8.alwaysValidSchema)(it, schema)) {
             cxt.fail();
             return;
         }
@@ -6370,35 +6385,35 @@ const def$7 = {
     },
     error: { message: "must NOT be valid" },
 };
-not.default = def$7;
+not.default = def$g;
 
 var anyOf = {};
 
 Object.defineProperty(anyOf, "__esModule", { value: true });
 const code_1 = code;
-const def$6 = {
+const def$f = {
     keyword: "anyOf",
     schemaType: "array",
     trackErrors: true,
     code: code_1.validateUnion,
     error: { message: "must match a schema in anyOf" },
 };
-anyOf.default = def$6;
+anyOf.default = def$f;
 
 var oneOf$1 = {};
 
 Object.defineProperty(oneOf$1, "__esModule", { value: true });
-const codegen_1$3 = codegen;
-const util_1$3 = util;
-const error$3 = {
+const codegen_1$7 = codegen;
+const util_1$7 = util;
+const error$5 = {
     message: "must match exactly one schema in oneOf",
-    params: ({ params }) => codegen_1$3._ `{passingSchemas: ${params.passing}}`,
+    params: ({ params }) => (0, codegen_1$7._) `{passingSchemas: ${params.passing}}`,
 };
-const def$5 = {
+const def$e = {
     keyword: "oneOf",
     schemaType: "array",
     trackErrors: true,
-    error: error$3,
+    error: error$5,
     code(cxt) {
         const { gen, schema, parentSchema, it } = cxt;
         /* istanbul ignore if */
@@ -6417,7 +6432,7 @@ const def$5 = {
         function validateOneOf() {
             schArr.forEach((sch, i) => {
                 let schCxt;
-                if (util_1$3.alwaysValidSchema(it, sch)) {
+                if ((0, util_1$7.alwaysValidSchema)(it, sch)) {
                     gen.var(schValid, true);
                 }
                 else {
@@ -6429,28 +6444,28 @@ const def$5 = {
                 }
                 if (i > 0) {
                     gen
-                        .if(codegen_1$3._ `${schValid} && ${valid}`)
+                        .if((0, codegen_1$7._) `${schValid} && ${valid}`)
                         .assign(valid, false)
-                        .assign(passing, codegen_1$3._ `[${passing}, ${i}]`)
+                        .assign(passing, (0, codegen_1$7._) `[${passing}, ${i}]`)
                         .else();
                 }
                 gen.if(schValid, () => {
                     gen.assign(valid, true);
                     gen.assign(passing, i);
                     if (schCxt)
-                        cxt.mergeEvaluated(schCxt, codegen_1$3.Name);
+                        cxt.mergeEvaluated(schCxt, codegen_1$7.Name);
                 });
             });
         }
     },
 };
-oneOf$1.default = def$5;
+oneOf$1.default = def$e;
 
-var allOf = {};
+var allOf$1 = {};
 
-Object.defineProperty(allOf, "__esModule", { value: true });
-const util_1$2 = util;
-const def$4 = {
+Object.defineProperty(allOf$1, "__esModule", { value: true });
+const util_1$6 = util;
+const def$d = {
     keyword: "allOf",
     schemaType: "array",
     code(cxt) {
@@ -6460,7 +6475,7 @@ const def$4 = {
             throw new Error("ajv implementation error");
         const valid = gen.name("valid");
         schema.forEach((sch, i) => {
-            if (util_1$2.alwaysValidSchema(it, sch))
+            if ((0, util_1$6.alwaysValidSchema)(it, sch))
                 return;
             const schCxt = cxt.subschema({ keyword: "allOf", schemaProp: i }, valid);
             cxt.ok(valid);
@@ -6468,26 +6483,26 @@ const def$4 = {
         });
     },
 };
-allOf.default = def$4;
+allOf$1.default = def$d;
 
 var _if = {};
 
 Object.defineProperty(_if, "__esModule", { value: true });
-const codegen_1$2 = codegen;
-const util_1$1 = util;
-const error$2 = {
-    message: ({ params }) => codegen_1$2.str `must match "${params.ifClause}" schema`,
-    params: ({ params }) => codegen_1$2._ `{failingKeyword: ${params.ifClause}}`,
+const codegen_1$6 = codegen;
+const util_1$5 = util;
+const error$4 = {
+    message: ({ params }) => (0, codegen_1$6.str) `must match "${params.ifClause}" schema`,
+    params: ({ params }) => (0, codegen_1$6._) `{failingKeyword: ${params.ifClause}}`,
 };
-const def$3 = {
+const def$c = {
     keyword: "if",
     schemaType: ["object", "boolean"],
     trackErrors: true,
-    error: error$2,
+    error: error$4,
     code(cxt) {
         const { gen, parentSchema, it } = cxt;
         if (parentSchema.then === undefined && parentSchema.else === undefined) {
-            util_1$1.checkStrictMode(it, '"if" without "then" and "else" is ignored');
+            (0, util_1$5.checkStrictMode)(it, '"if" without "then" and "else" is ignored');
         }
         const hasThen = hasSchema(it, "then");
         const hasElse = hasSchema(it, "else");
@@ -6506,7 +6521,7 @@ const def$3 = {
             gen.if(schValid, validateClause("then"));
         }
         else {
-            gen.if(codegen_1$2.not(schValid), validateClause("else"));
+            gen.if((0, codegen_1$6.not)(schValid), validateClause("else"));
         }
         cxt.pass(valid, () => cxt.error(true));
         function validateIf() {
@@ -6524,7 +6539,7 @@ const def$3 = {
                 gen.assign(valid, schValid);
                 cxt.mergeValidEvaluated(schCxt, valid);
                 if (ifClause)
-                    gen.assign(ifClause, codegen_1$2._ `${keyword}`);
+                    gen.assign(ifClause, (0, codegen_1$6._) `${keyword}`);
                 else
                     cxt.setParams({ ifClause: keyword });
             };
@@ -6533,39 +6548,39 @@ const def$3 = {
 };
 function hasSchema(it, keyword) {
     const schema = it.schema[keyword];
-    return schema !== undefined && !util_1$1.alwaysValidSchema(it, schema);
+    return schema !== undefined && !(0, util_1$5.alwaysValidSchema)(it, schema);
 }
-_if.default = def$3;
+_if.default = def$c;
 
 var thenElse = {};
 
 Object.defineProperty(thenElse, "__esModule", { value: true });
-const util_1 = util;
-const def$2 = {
+const util_1$4 = util;
+const def$b = {
     keyword: ["then", "else"],
     schemaType: ["object", "boolean"],
     code({ keyword, parentSchema, it }) {
         if (parentSchema.if === undefined)
-            util_1.checkStrictMode(it, `"${keyword}" without "if" is ignored`);
+            (0, util_1$4.checkStrictMode)(it, `"${keyword}" without "if" is ignored`);
     },
 };
-thenElse.default = def$2;
+thenElse.default = def$b;
 
-Object.defineProperty(applicator, "__esModule", { value: true });
+Object.defineProperty(applicator$1, "__esModule", { value: true });
 const additionalItems_1 = additionalItems;
 const prefixItems_1 = prefixItems;
 const items_1 = items;
 const items2020_1 = items2020;
 const contains_1 = contains;
-const dependencies_1 = dependencies;
+const dependencies_1$2 = dependencies;
 const propertyNames_1 = propertyNames;
 const additionalProperties_1 = additionalProperties$h;
-const properties_1 = properties$i;
+const properties_1 = properties$p;
 const patternProperties_1 = patternProperties;
 const not_1 = not;
 const anyOf_1 = anyOf;
 const oneOf_1 = oneOf$1;
-const allOf_1 = allOf;
+const allOf_1 = allOf$1;
 const if_1 = _if;
 const thenElse_1 = thenElse;
 function getApplicator(draft2020 = false) {
@@ -6580,7 +6595,7 @@ function getApplicator(draft2020 = false) {
         // object
         propertyNames_1.default,
         additionalProperties_1.default,
-        dependencies_1.default,
+        dependencies_1$2.default,
         properties_1.default,
         patternProperties_1.default,
     ];
@@ -6592,17 +6607,303 @@ function getApplicator(draft2020 = false) {
     applicator.push(contains_1.default);
     return applicator;
 }
-applicator.default = getApplicator;
+applicator$1.default = getApplicator;
+
+var dynamic$1 = {};
+
+var dynamicAnchor$1 = {};
+
+Object.defineProperty(dynamicAnchor$1, "__esModule", { value: true });
+dynamicAnchor$1.dynamicAnchor = void 0;
+const codegen_1$5 = codegen;
+const names_1$2 = names$1;
+const compile_1 = compile;
+const ref_1$1 = ref;
+const def$a = {
+    keyword: "$dynamicAnchor",
+    schemaType: "string",
+    code: (cxt) => dynamicAnchor(cxt, cxt.schema),
+};
+function dynamicAnchor(cxt, anchor) {
+    const { gen, it } = cxt;
+    it.schemaEnv.root.dynamicAnchors[anchor] = true;
+    const v = (0, codegen_1$5._) `${names_1$2.default.dynamicAnchors}${(0, codegen_1$5.getProperty)(anchor)}`;
+    const validate = it.errSchemaPath === "#" ? it.validateName : _getValidate(cxt);
+    gen.if((0, codegen_1$5._) `!${v}`, () => gen.assign(v, validate));
+}
+dynamicAnchor$1.dynamicAnchor = dynamicAnchor;
+function _getValidate(cxt) {
+    const { schemaEnv, schema, self } = cxt.it;
+    const { root, baseId, localRefs, meta } = schemaEnv.root;
+    const { schemaId } = self.opts;
+    const sch = new compile_1.SchemaEnv({ schema, schemaId, root, baseId, localRefs, meta });
+    compile_1.compileSchema.call(self, sch);
+    return (0, ref_1$1.getValidate)(cxt, sch);
+}
+dynamicAnchor$1.default = def$a;
+
+var dynamicRef$1 = {};
+
+Object.defineProperty(dynamicRef$1, "__esModule", { value: true });
+dynamicRef$1.dynamicRef = void 0;
+const codegen_1$4 = codegen;
+const names_1$1 = names$1;
+const ref_1 = ref;
+const def$9 = {
+    keyword: "$dynamicRef",
+    schemaType: "string",
+    code: (cxt) => dynamicRef(cxt, cxt.schema),
+};
+function dynamicRef(cxt, ref) {
+    const { gen, keyword, it } = cxt;
+    if (ref[0] !== "#")
+        throw new Error(`"${keyword}" only supports hash fragment reference`);
+    const anchor = ref.slice(1);
+    if (it.allErrors) {
+        _dynamicRef();
+    }
+    else {
+        const valid = gen.let("valid", false);
+        _dynamicRef(valid);
+        cxt.ok(valid);
+    }
+    function _dynamicRef(valid) {
+        // TODO the assumption here is that `recursiveRef: #` always points to the root
+        // of the schema object, which is not correct, because there may be $id that
+        // makes # point to it, and the target schema may not contain dynamic/recursiveAnchor.
+        // Because of that 2 tests in recursiveRef.json fail.
+        // This is a similar problem to #815 (`$id` doesn't alter resolution scope for `{ "$ref": "#" }`).
+        // (This problem is not tested in JSON-Schema-Test-Suite)
+        if (it.schemaEnv.root.dynamicAnchors[anchor]) {
+            const v = gen.let("_v", (0, codegen_1$4._) `${names_1$1.default.dynamicAnchors}${(0, codegen_1$4.getProperty)(anchor)}`);
+            gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid));
+        }
+        else {
+            _callRef(it.validateName, valid)();
+        }
+    }
+    function _callRef(validate, valid) {
+        return valid
+            ? () => gen.block(() => {
+                (0, ref_1.callRef)(cxt, validate);
+                gen.let(valid, true);
+            })
+            : () => (0, ref_1.callRef)(cxt, validate);
+    }
+}
+dynamicRef$1.dynamicRef = dynamicRef;
+dynamicRef$1.default = def$9;
+
+var recursiveAnchor = {};
+
+Object.defineProperty(recursiveAnchor, "__esModule", { value: true });
+const dynamicAnchor_1$1 = dynamicAnchor$1;
+const util_1$3 = util;
+const def$8 = {
+    keyword: "$recursiveAnchor",
+    schemaType: "boolean",
+    code(cxt) {
+        if (cxt.schema)
+            (0, dynamicAnchor_1$1.dynamicAnchor)(cxt, "");
+        else
+            (0, util_1$3.checkStrictMode)(cxt.it, "$recursiveAnchor: false is ignored");
+    },
+};
+recursiveAnchor.default = def$8;
+
+var recursiveRef = {};
+
+Object.defineProperty(recursiveRef, "__esModule", { value: true });
+const dynamicRef_1$1 = dynamicRef$1;
+const def$7 = {
+    keyword: "$recursiveRef",
+    schemaType: "string",
+    code: (cxt) => (0, dynamicRef_1$1.dynamicRef)(cxt, cxt.schema),
+};
+recursiveRef.default = def$7;
+
+Object.defineProperty(dynamic$1, "__esModule", { value: true });
+const dynamicAnchor_1 = dynamicAnchor$1;
+const dynamicRef_1 = dynamicRef$1;
+const recursiveAnchor_1 = recursiveAnchor;
+const recursiveRef_1 = recursiveRef;
+const dynamic = [dynamicAnchor_1.default, dynamicRef_1.default, recursiveAnchor_1.default, recursiveRef_1.default];
+dynamic$1.default = dynamic;
+
+var next$1 = {};
+
+var dependentRequired = {};
+
+Object.defineProperty(dependentRequired, "__esModule", { value: true });
+const dependencies_1$1 = dependencies;
+const def$6 = {
+    keyword: "dependentRequired",
+    type: "object",
+    schemaType: "object",
+    error: dependencies_1$1.error,
+    code: (cxt) => (0, dependencies_1$1.validatePropertyDeps)(cxt),
+};
+dependentRequired.default = def$6;
+
+var dependentSchemas = {};
+
+Object.defineProperty(dependentSchemas, "__esModule", { value: true });
+const dependencies_1 = dependencies;
+const def$5 = {
+    keyword: "dependentSchemas",
+    type: "object",
+    schemaType: "object",
+    code: (cxt) => (0, dependencies_1.validateSchemaDeps)(cxt),
+};
+dependentSchemas.default = def$5;
+
+var limitContains = {};
+
+Object.defineProperty(limitContains, "__esModule", { value: true });
+const util_1$2 = util;
+const def$4 = {
+    keyword: ["maxContains", "minContains"],
+    type: "array",
+    schemaType: "number",
+    code({ keyword, parentSchema, it }) {
+        if (parentSchema.contains === undefined) {
+            (0, util_1$2.checkStrictMode)(it, `"${keyword}" without "contains" is ignored`);
+        }
+    },
+};
+limitContains.default = def$4;
+
+Object.defineProperty(next$1, "__esModule", { value: true });
+const dependentRequired_1 = dependentRequired;
+const dependentSchemas_1 = dependentSchemas;
+const limitContains_1 = limitContains;
+const next = [dependentRequired_1.default, dependentSchemas_1.default, limitContains_1.default];
+next$1.default = next;
+
+var unevaluated$2 = {};
+
+var unevaluatedProperties = {};
+
+Object.defineProperty(unevaluatedProperties, "__esModule", { value: true });
+const codegen_1$3 = codegen;
+const util_1$1 = util;
+const names_1 = names$1;
+const error$3 = {
+    message: "must NOT have unevaluated properties",
+    params: ({ params }) => (0, codegen_1$3._) `{unevaluatedProperty: ${params.unevaluatedProperty}}`,
+};
+const def$3 = {
+    keyword: "unevaluatedProperties",
+    type: "object",
+    schemaType: ["boolean", "object"],
+    trackErrors: true,
+    error: error$3,
+    code(cxt) {
+        const { gen, schema, data, errsCount, it } = cxt;
+        /* istanbul ignore if */
+        if (!errsCount)
+            throw new Error("ajv implementation error");
+        const { allErrors, props } = it;
+        if (props instanceof codegen_1$3.Name) {
+            gen.if((0, codegen_1$3._) `${props} !== true`, () => gen.forIn("key", data, (key) => gen.if(unevaluatedDynamic(props, key), () => unevaluatedPropCode(key))));
+        }
+        else if (props !== true) {
+            gen.forIn("key", data, (key) => props === undefined
+                ? unevaluatedPropCode(key)
+                : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key)));
+        }
+        it.props = true;
+        cxt.ok((0, codegen_1$3._) `${errsCount} === ${names_1.default.errors}`);
+        function unevaluatedPropCode(key) {
+            if (schema === false) {
+                cxt.setParams({ unevaluatedProperty: key });
+                cxt.error();
+                if (!allErrors)
+                    gen.break();
+                return;
+            }
+            if (!(0, util_1$1.alwaysValidSchema)(it, schema)) {
+                const valid = gen.name("valid");
+                cxt.subschema({
+                    keyword: "unevaluatedProperties",
+                    dataProp: key,
+                    dataPropType: util_1$1.Type.Str,
+                }, valid);
+                if (!allErrors)
+                    gen.if((0, codegen_1$3.not)(valid), () => gen.break());
+            }
+        }
+        function unevaluatedDynamic(evaluatedProps, key) {
+            return (0, codegen_1$3._) `!${evaluatedProps} || !${evaluatedProps}[${key}]`;
+        }
+        function unevaluatedStatic(evaluatedProps, key) {
+            const ps = [];
+            for (const p in evaluatedProps) {
+                if (evaluatedProps[p] === true)
+                    ps.push((0, codegen_1$3._) `${key} !== ${p}`);
+            }
+            return (0, codegen_1$3.and)(...ps);
+        }
+    },
+};
+unevaluatedProperties.default = def$3;
+
+var unevaluatedItems = {};
+
+Object.defineProperty(unevaluatedItems, "__esModule", { value: true });
+const codegen_1$2 = codegen;
+const util_1 = util;
+const error$2 = {
+    message: ({ params: { len } }) => (0, codegen_1$2.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$2._) `{limit: ${len}}`,
+};
+const def$2 = {
+    keyword: "unevaluatedItems",
+    type: "array",
+    schemaType: ["boolean", "object"],
+    error: error$2,
+    code(cxt) {
+        const { gen, schema, data, it } = cxt;
+        const items = it.items || 0;
+        if (items === true)
+            return;
+        const len = gen.const("len", (0, codegen_1$2._) `${data}.length`);
+        if (schema === false) {
+            cxt.setParams({ len: items });
+            cxt.fail((0, codegen_1$2._) `${len} > ${items}`);
+        }
+        else if (typeof schema == "object" && !(0, util_1.alwaysValidSchema)(it, schema)) {
+            const valid = gen.var("valid", (0, codegen_1$2._) `${len} <= ${items}`);
+            gen.if((0, codegen_1$2.not)(valid), () => validateItems(valid, items));
+            cxt.ok(valid);
+        }
+        it.items = true;
+        function validateItems(valid, from) {
+            gen.forRange("i", from, len, (i) => {
+                cxt.subschema({ keyword: "unevaluatedItems", dataProp: i, dataPropType: util_1.Type.Num }, valid);
+                if (!it.allErrors)
+                    gen.if((0, codegen_1$2.not)(valid), () => gen.break());
+            });
+        }
+    },
+};
+unevaluatedItems.default = def$2;
+
+Object.defineProperty(unevaluated$2, "__esModule", { value: true });
+const unevaluatedProperties_1 = unevaluatedProperties;
+const unevaluatedItems_1 = unevaluatedItems;
+const unevaluated$1 = [unevaluatedProperties_1.default, unevaluatedItems_1.default];
+unevaluated$2.default = unevaluated$1;
+
+var format$3 = {};
 
 var format$2 = {};
 
-var format$1 = {};
-
-Object.defineProperty(format$1, "__esModule", { value: true });
+Object.defineProperty(format$2, "__esModule", { value: true });
 const codegen_1$1 = codegen;
 const error$1 = {
-    message: ({ schemaCode }) => codegen_1$1.str `must match format "${schemaCode}"`,
-    params: ({ schemaCode }) => codegen_1$1._ `{format: ${schemaCode}}`,
+    message: ({ schemaCode }) => (0, codegen_1$1.str) `must match format "${schemaCode}"`,
+    params: ({ schemaCode }) => (0, codegen_1$1._) `{format: ${schemaCode}}`,
 };
 const def$1 = {
     keyword: "format",
@@ -6624,23 +6925,23 @@ const def$1 = {
                 ref: self.formats,
                 code: opts.code.formats,
             });
-            const fDef = gen.const("fDef", codegen_1$1._ `${fmts}[${schemaCode}]`);
+            const fDef = gen.const("fDef", (0, codegen_1$1._) `${fmts}[${schemaCode}]`);
             const fType = gen.let("fType");
             const format = gen.let("format");
             // TODO simplify
-            gen.if(codegen_1$1._ `typeof ${fDef} == "object" && !(${fDef} instanceof RegExp)`, () => gen.assign(fType, codegen_1$1._ `${fDef}.type || "string"`).assign(format, codegen_1$1._ `${fDef}.validate`), () => gen.assign(fType, codegen_1$1._ `"string"`).assign(format, fDef));
-            cxt.fail$data(codegen_1$1.or(unknownFmt(), invalidFmt()));
+            gen.if((0, codegen_1$1._) `typeof ${fDef} == "object" && !(${fDef} instanceof RegExp)`, () => gen.assign(fType, (0, codegen_1$1._) `${fDef}.type || "string"`).assign(format, (0, codegen_1$1._) `${fDef}.validate`), () => gen.assign(fType, (0, codegen_1$1._) `"string"`).assign(format, fDef));
+            cxt.fail$data((0, codegen_1$1.or)(unknownFmt(), invalidFmt()));
             function unknownFmt() {
                 if (opts.strictSchema === false)
                     return codegen_1$1.nil;
-                return codegen_1$1._ `${schemaCode} && !${format}`;
+                return (0, codegen_1$1._) `${schemaCode} && !${format}`;
             }
             function invalidFmt() {
                 const callFormat = schemaEnv.$async
-                    ? codegen_1$1._ `(${fDef}.async ? await ${format}(${data}) : ${format}(${data}))`
-                    : codegen_1$1._ `${format}(${data})`;
-                const validData = codegen_1$1._ `(typeof ${format} == "function" ? ${callFormat} : ${format}.test(${data}))`;
-                return codegen_1$1._ `${format} && ${format} !== true && ${fType} === ${ruleType} && !${validData}`;
+                    ? (0, codegen_1$1._) `(${fDef}.async ? await ${format}(${data}) : ${format}(${data}))`
+                    : (0, codegen_1$1._) `${format}(${data})`;
+                const validData = (0, codegen_1$1._) `(typeof ${format} == "function" ? ${callFormat} : ${format}.test(${data}))`;
+                return (0, codegen_1$1._) `${format} && ${format} !== true && ${fType} === ${ruleType} && !${validData}`;
             }
         }
         function validateFormat() {
@@ -6666,13 +6967,13 @@ const def$1 = {
             }
             function getFormat(fmtDef) {
                 const code = fmtDef instanceof RegExp
-                    ? codegen_1$1.regexpCode(fmtDef)
+                    ? (0, codegen_1$1.regexpCode)(fmtDef)
                     : opts.code.formats
-                        ? codegen_1$1._ `${opts.code.formats}${codegen_1$1.getProperty(schema)}`
+                        ? (0, codegen_1$1._) `${opts.code.formats}${(0, codegen_1$1.getProperty)(schema)}`
                         : undefined;
                 const fmt = gen.scopeValue("formats", { key: schema, ref: fmtDef, code });
                 if (typeof fmtDef == "object" && !(fmtDef instanceof RegExp)) {
-                    return [fmtDef.type || "string", fmtDef.validate, codegen_1$1._ `${fmt}.validate`];
+                    return [fmtDef.type || "string", fmtDef.validate, (0, codegen_1$1._) `${fmt}.validate`];
                 }
                 return ["string", fmtDef, fmt];
             }
@@ -6680,25 +6981,25 @@ const def$1 = {
                 if (typeof formatDef == "object" && !(formatDef instanceof RegExp) && formatDef.async) {
                     if (!schemaEnv.$async)
                         throw new Error("async format in sync schema");
-                    return codegen_1$1._ `await ${fmtRef}(${data})`;
+                    return (0, codegen_1$1._) `await ${fmtRef}(${data})`;
                 }
-                return typeof format == "function" ? codegen_1$1._ `${fmtRef}(${data})` : codegen_1$1._ `${fmtRef}.test(${data})`;
+                return typeof format == "function" ? (0, codegen_1$1._) `${fmtRef}(${data})` : (0, codegen_1$1._) `${fmtRef}.test(${data})`;
             }
         }
     },
 };
-format$1.default = def$1;
+format$2.default = def$1;
 
-Object.defineProperty(format$2, "__esModule", { value: true });
-const format_1$1 = format$1;
-const format = [format_1$1.default];
-format$2.default = format;
+Object.defineProperty(format$3, "__esModule", { value: true });
+const format_1$1 = format$2;
+const format$1 = [format_1$1.default];
+format$3.default = format$1;
 
-var metadata = {};
+var metadata$1 = {};
 
-Object.defineProperty(metadata, "__esModule", { value: true });
-metadata.contentVocabulary = metadata.metadataVocabulary = void 0;
-metadata.metadataVocabulary = [
+Object.defineProperty(metadata$1, "__esModule", { value: true });
+metadata$1.contentVocabulary = metadata$1.metadataVocabulary = void 0;
+metadata$1.metadataVocabulary = [
     "title",
     "description",
     "default",
@@ -6707,27 +7008,33 @@ metadata.metadataVocabulary = [
     "writeOnly",
     "examples",
 ];
-metadata.contentVocabulary = [
+metadata$1.contentVocabulary = [
     "contentMediaType",
     "contentEncoding",
     "contentSchema",
 ];
 
-Object.defineProperty(draft7, "__esModule", { value: true });
-const core_1 = core$1;
-const validation_1 = validation$1;
-const applicator_1 = applicator;
-const format_1 = format$2;
-const metadata_1 = metadata;
-const draft7Vocabularies = [
+Object.defineProperty(draft2020, "__esModule", { value: true });
+const core_1 = core$2;
+const validation_1 = validation$2;
+const applicator_1 = applicator$1;
+const dynamic_1 = dynamic$1;
+const next_1 = next$1;
+const unevaluated_1 = unevaluated$2;
+const format_1 = format$3;
+const metadata_1 = metadata$1;
+const draft2020Vocabularies = [
+    dynamic_1.default,
     core_1.default,
     validation_1.default,
-    applicator_1.default(),
+    (0, applicator_1.default)(true),
     format_1.default,
     metadata_1.metadataVocabulary,
     metadata_1.contentVocabulary,
+    next_1.default,
+    unevaluated_1.default,
 ];
-draft7.default = draft7Vocabularies;
+draft2020.default = draft2020Vocabularies;
 
 var discriminator = {};
 
@@ -6750,7 +7057,7 @@ const error = {
     message: ({ params: { discrError, tagName } }) => discrError === types_1.DiscrError.Tag
         ? `tag "${tagName}" must be string`
         : `value of tag "${tagName}" must be in oneOf`,
-    params: ({ params: { discrError, tag, tagName } }) => codegen_1._ `{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`,
+    params: ({ params: { discrError, tag, tagName } }) => (0, codegen_1._) `{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`,
 };
 const def = {
     keyword: "discriminator",
@@ -6771,14 +7078,14 @@ const def = {
         if (!oneOf)
             throw new Error("discriminator: requires oneOf keyword");
         const valid = gen.let("valid", false);
-        const tag = gen.const("tag", codegen_1._ `${data}${codegen_1.getProperty(tagName)}`);
-        gen.if(codegen_1._ `typeof ${tag} == "string"`, () => validateMapping(), () => cxt.error(false, { discrError: types_1.DiscrError.Tag, tag, tagName }));
+        const tag = gen.const("tag", (0, codegen_1._) `${data}${(0, codegen_1.getProperty)(tagName)}`);
+        gen.if((0, codegen_1._) `typeof ${tag} == "string"`, () => validateMapping(), () => cxt.error(false, { discrError: types_1.DiscrError.Tag, tag, tagName }));
         cxt.ok(valid);
         function validateMapping() {
             const mapping = getMapping();
             gen.if(false);
             for (const tagValue in mapping) {
-                gen.elseIf(codegen_1._ `${tag} === ${tagValue}`);
+                gen.elseIf((0, codegen_1._) `${tag} === ${tagValue}`);
                 gen.assign(valid, applyTagSchema(mapping[tagValue]));
             }
             gen.else();
@@ -6835,30 +7142,504 @@ const def = {
 };
 discriminator.default = def;
 
-var $schema = "http://json-schema.org/draft-07/schema#";
-var $id = "http://json-schema.org/draft-07/schema#";
-var title$i = "Core schema meta-schema";
-var definitions$3 = {
+var jsonSchema202012 = {};
+
+var $schema$7 = "https://json-schema.org/draft/2020-12/schema";
+var $id$9 = "https://json-schema.org/draft/2020-12/schema";
+var $vocabulary$7 = {
+	"https://json-schema.org/draft/2020-12/vocab/core": true,
+	"https://json-schema.org/draft/2020-12/vocab/applicator": true,
+	"https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+	"https://json-schema.org/draft/2020-12/vocab/validation": true,
+	"https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+	"https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+	"https://json-schema.org/draft/2020-12/vocab/content": true
+};
+var $dynamicAnchor$7 = "meta";
+var title$p = "Core and Validation specifications meta-schema";
+var allOf = [
+	{
+		$ref: "meta/core"
+	},
+	{
+		$ref: "meta/applicator"
+	},
+	{
+		$ref: "meta/unevaluated"
+	},
+	{
+		$ref: "meta/validation"
+	},
+	{
+		$ref: "meta/meta-data"
+	},
+	{
+		$ref: "meta/format-annotation"
+	},
+	{
+		$ref: "meta/content"
+	}
+];
+var type$p = [
+	"object",
+	"boolean"
+];
+var $comment = "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.";
+var properties$o = {
+	definitions: {
+		$comment: "\"definitions\" has been replaced by \"$defs\".",
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		deprecated: true,
+		"default": {
+		}
+	},
+	dependencies: {
+		$comment: "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+		type: "object",
+		additionalProperties: {
+			anyOf: [
+				{
+					$dynamicRef: "#meta"
+				},
+				{
+					$ref: "meta/validation#/$defs/stringArray"
+				}
+			]
+		},
+		deprecated: true,
+		"default": {
+		}
+	},
+	$recursiveAnchor: {
+		$comment: "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+		$ref: "meta/core#/$defs/anchorString",
+		deprecated: true
+	},
+	$recursiveRef: {
+		$comment: "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+		$ref: "meta/core#/$defs/uriReferenceString",
+		deprecated: true
+	}
+};
+var require$$0 = {
+	$schema: $schema$7,
+	$id: $id$9,
+	$vocabulary: $vocabulary$7,
+	$dynamicAnchor: $dynamicAnchor$7,
+	title: title$p,
+	allOf: allOf,
+	type: type$p,
+	$comment: $comment,
+	properties: properties$o
+};
+
+var $schema$6 = "https://json-schema.org/draft/2020-12/schema";
+var $id$8 = "https://json-schema.org/draft/2020-12/meta/applicator";
+var $vocabulary$6 = {
+	"https://json-schema.org/draft/2020-12/vocab/applicator": true
+};
+var $dynamicAnchor$6 = "meta";
+var title$o = "Applicator vocabulary meta-schema";
+var type$o = [
+	"object",
+	"boolean"
+];
+var properties$n = {
+	prefixItems: {
+		$ref: "#/$defs/schemaArray"
+	},
+	items: {
+		$dynamicRef: "#meta"
+	},
+	contains: {
+		$dynamicRef: "#meta"
+	},
+	additionalProperties: {
+		$dynamicRef: "#meta"
+	},
+	properties: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		"default": {
+		}
+	},
+	patternProperties: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		propertyNames: {
+			format: "regex"
+		},
+		"default": {
+		}
+	},
+	dependentSchemas: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		"default": {
+		}
+	},
+	propertyNames: {
+		$dynamicRef: "#meta"
+	},
+	"if": {
+		$dynamicRef: "#meta"
+	},
+	then: {
+		$dynamicRef: "#meta"
+	},
+	"else": {
+		$dynamicRef: "#meta"
+	},
+	allOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	anyOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	oneOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	not: {
+		$dynamicRef: "#meta"
+	}
+};
+var $defs$2 = {
 	schemaArray: {
 		type: "array",
 		minItems: 1,
 		items: {
-			$ref: "#"
+			$dynamicRef: "#meta"
+		}
+	}
+};
+var require$$1 = {
+	$schema: $schema$6,
+	$id: $id$8,
+	$vocabulary: $vocabulary$6,
+	$dynamicAnchor: $dynamicAnchor$6,
+	title: title$o,
+	type: type$o,
+	properties: properties$n,
+	$defs: $defs$2
+};
+
+var $schema$5 = "https://json-schema.org/draft/2020-12/schema";
+var $id$7 = "https://json-schema.org/draft/2020-12/meta/unevaluated";
+var $vocabulary$5 = {
+	"https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+};
+var $dynamicAnchor$5 = "meta";
+var title$n = "Unevaluated applicator vocabulary meta-schema";
+var type$n = [
+	"object",
+	"boolean"
+];
+var properties$m = {
+	unevaluatedItems: {
+		$dynamicRef: "#meta"
+	},
+	unevaluatedProperties: {
+		$dynamicRef: "#meta"
+	}
+};
+var require$$2 = {
+	$schema: $schema$5,
+	$id: $id$7,
+	$vocabulary: $vocabulary$5,
+	$dynamicAnchor: $dynamicAnchor$5,
+	title: title$n,
+	type: type$n,
+	properties: properties$m
+};
+
+var $schema$4 = "https://json-schema.org/draft/2020-12/schema";
+var $id$6 = "https://json-schema.org/draft/2020-12/meta/content";
+var $vocabulary$4 = {
+	"https://json-schema.org/draft/2020-12/vocab/content": true
+};
+var $dynamicAnchor$4 = "meta";
+var title$m = "Content vocabulary meta-schema";
+var type$m = [
+	"object",
+	"boolean"
+];
+var properties$l = {
+	contentEncoding: {
+		type: "string"
+	},
+	contentMediaType: {
+		type: "string"
+	},
+	contentSchema: {
+		$dynamicRef: "#meta"
+	}
+};
+var require$$3 = {
+	$schema: $schema$4,
+	$id: $id$6,
+	$vocabulary: $vocabulary$4,
+	$dynamicAnchor: $dynamicAnchor$4,
+	title: title$m,
+	type: type$m,
+	properties: properties$l
+};
+
+var $schema$3 = "https://json-schema.org/draft/2020-12/schema";
+var $id$5 = "https://json-schema.org/draft/2020-12/meta/core";
+var $vocabulary$3 = {
+	"https://json-schema.org/draft/2020-12/vocab/core": true
+};
+var $dynamicAnchor$3 = "meta";
+var title$l = "Core vocabulary meta-schema";
+var type$l = [
+	"object",
+	"boolean"
+];
+var properties$k = {
+	$id: {
+		$ref: "#/$defs/uriReferenceString",
+		$comment: "Non-empty fragments not allowed.",
+		pattern: "^[^#]*#?$"
+	},
+	$schema: {
+		$ref: "#/$defs/uriString"
+	},
+	$ref: {
+		$ref: "#/$defs/uriReferenceString"
+	},
+	$anchor: {
+		$ref: "#/$defs/anchorString"
+	},
+	$dynamicRef: {
+		$ref: "#/$defs/uriReferenceString"
+	},
+	$dynamicAnchor: {
+		$ref: "#/$defs/anchorString"
+	},
+	$vocabulary: {
+		type: "object",
+		propertyNames: {
+			$ref: "#/$defs/uriString"
+		},
+		additionalProperties: {
+			type: "boolean"
 		}
 	},
+	$comment: {
+		type: "string"
+	},
+	$defs: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		}
+	}
+};
+var $defs$1 = {
+	anchorString: {
+		type: "string",
+		pattern: "^[A-Za-z_][-A-Za-z0-9._]*$"
+	},
+	uriString: {
+		type: "string",
+		format: "uri"
+	},
+	uriReferenceString: {
+		type: "string",
+		format: "uri-reference"
+	}
+};
+var require$$4 = {
+	$schema: $schema$3,
+	$id: $id$5,
+	$vocabulary: $vocabulary$3,
+	$dynamicAnchor: $dynamicAnchor$3,
+	title: title$l,
+	type: type$l,
+	properties: properties$k,
+	$defs: $defs$1
+};
+
+var $schema$2 = "https://json-schema.org/draft/2020-12/schema";
+var $id$4 = "https://json-schema.org/draft/2020-12/meta/format-annotation";
+var $vocabulary$2 = {
+	"https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+};
+var $dynamicAnchor$2 = "meta";
+var title$k = "Format vocabulary meta-schema for annotation results";
+var type$k = [
+	"object",
+	"boolean"
+];
+var properties$j = {
+	format: {
+		type: "string"
+	}
+};
+var require$$5 = {
+	$schema: $schema$2,
+	$id: $id$4,
+	$vocabulary: $vocabulary$2,
+	$dynamicAnchor: $dynamicAnchor$2,
+	title: title$k,
+	type: type$k,
+	properties: properties$j
+};
+
+var $schema$1 = "https://json-schema.org/draft/2020-12/schema";
+var $id$3 = "https://json-schema.org/draft/2020-12/meta/meta-data";
+var $vocabulary$1 = {
+	"https://json-schema.org/draft/2020-12/vocab/meta-data": true
+};
+var $dynamicAnchor$1 = "meta";
+var title$j = "Meta-data vocabulary meta-schema";
+var type$j = [
+	"object",
+	"boolean"
+];
+var properties$i = {
+	title: {
+		type: "string"
+	},
+	description: {
+		type: "string"
+	},
+	"default": true,
+	deprecated: {
+		type: "boolean",
+		"default": false
+	},
+	readOnly: {
+		type: "boolean",
+		"default": false
+	},
+	writeOnly: {
+		type: "boolean",
+		"default": false
+	},
+	examples: {
+		type: "array",
+		items: true
+	}
+};
+var require$$6 = {
+	$schema: $schema$1,
+	$id: $id$3,
+	$vocabulary: $vocabulary$1,
+	$dynamicAnchor: $dynamicAnchor$1,
+	title: title$j,
+	type: type$j,
+	properties: properties$i
+};
+
+var $schema = "https://json-schema.org/draft/2020-12/schema";
+var $id$2 = "https://json-schema.org/draft/2020-12/meta/validation";
+var $vocabulary = {
+	"https://json-schema.org/draft/2020-12/vocab/validation": true
+};
+var $dynamicAnchor = "meta";
+var title$i = "Validation vocabulary meta-schema";
+var type$i = [
+	"object",
+	"boolean"
+];
+var properties$h = {
+	type: {
+		anyOf: [
+			{
+				$ref: "#/$defs/simpleTypes"
+			},
+			{
+				type: "array",
+				items: {
+					$ref: "#/$defs/simpleTypes"
+				},
+				minItems: 1,
+				uniqueItems: true
+			}
+		]
+	},
+	"const": true,
+	"enum": {
+		type: "array",
+		items: true
+	},
+	multipleOf: {
+		type: "number",
+		exclusiveMinimum: 0
+	},
+	maximum: {
+		type: "number"
+	},
+	exclusiveMaximum: {
+		type: "number"
+	},
+	minimum: {
+		type: "number"
+	},
+	exclusiveMinimum: {
+		type: "number"
+	},
+	maxLength: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minLength: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	pattern: {
+		type: "string",
+		format: "regex"
+	},
+	maxItems: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minItems: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	uniqueItems: {
+		type: "boolean",
+		"default": false
+	},
+	maxContains: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minContains: {
+		$ref: "#/$defs/nonNegativeInteger",
+		"default": 1
+	},
+	maxProperties: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minProperties: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	required: {
+		$ref: "#/$defs/stringArray"
+	},
+	dependentRequired: {
+		type: "object",
+		additionalProperties: {
+			$ref: "#/$defs/stringArray"
+		}
+	}
+};
+var $defs = {
 	nonNegativeInteger: {
 		type: "integer",
 		minimum: 0
 	},
 	nonNegativeIntegerDefault0: {
-		allOf: [
-			{
-				$ref: "#/definitions/nonNegativeInteger"
-			},
-			{
-				"default": 0
-			}
-		]
+		$ref: "#/$defs/nonNegativeInteger",
+		"default": 0
 	},
 	simpleTypes: {
 		"enum": [
@@ -6881,236 +7662,74 @@ var definitions$3 = {
 		]
 	}
 };
-var type$i = [
-	"object",
-	"boolean"
-];
-var properties$h = {
-	$id: {
-		type: "string",
-		format: "uri-reference"
-	},
-	$schema: {
-		type: "string",
-		format: "uri"
-	},
-	$ref: {
-		type: "string",
-		format: "uri-reference"
-	},
-	$comment: {
-		type: "string"
-	},
-	title: {
-		type: "string"
-	},
-	description: {
-		type: "string"
-	},
-	"default": true,
-	readOnly: {
-		type: "boolean",
-		"default": false
-	},
-	examples: {
-		type: "array",
-		items: true
-	},
-	multipleOf: {
-		type: "number",
-		exclusiveMinimum: 0
-	},
-	maximum: {
-		type: "number"
-	},
-	exclusiveMaximum: {
-		type: "number"
-	},
-	minimum: {
-		type: "number"
-	},
-	exclusiveMinimum: {
-		type: "number"
-	},
-	maxLength: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minLength: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	pattern: {
-		type: "string",
-		format: "regex"
-	},
-	additionalItems: {
-		$ref: "#"
-	},
-	items: {
-		anyOf: [
-			{
-				$ref: "#"
-			},
-			{
-				$ref: "#/definitions/schemaArray"
-			}
-		],
-		"default": true
-	},
-	maxItems: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minItems: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	uniqueItems: {
-		type: "boolean",
-		"default": false
-	},
-	contains: {
-		$ref: "#"
-	},
-	maxProperties: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minProperties: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	required: {
-		$ref: "#/definitions/stringArray"
-	},
-	additionalProperties: {
-		$ref: "#"
-	},
-	definitions: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		"default": {
-		}
-	},
-	properties: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		"default": {
-		}
-	},
-	patternProperties: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		propertyNames: {
-			format: "regex"
-		},
-		"default": {
-		}
-	},
-	dependencies: {
-		type: "object",
-		additionalProperties: {
-			anyOf: [
-				{
-					$ref: "#"
-				},
-				{
-					$ref: "#/definitions/stringArray"
-				}
-			]
-		}
-	},
-	propertyNames: {
-		$ref: "#"
-	},
-	"const": true,
-	"enum": {
-		type: "array",
-		items: true,
-		minItems: 1,
-		uniqueItems: true
-	},
-	type: {
-		anyOf: [
-			{
-				$ref: "#/definitions/simpleTypes"
-			},
-			{
-				type: "array",
-				items: {
-					$ref: "#/definitions/simpleTypes"
-				},
-				minItems: 1,
-				uniqueItems: true
-			}
-		]
-	},
-	format: {
-		type: "string"
-	},
-	contentMediaType: {
-		type: "string"
-	},
-	contentEncoding: {
-		type: "string"
-	},
-	"if": {
-		$ref: "#"
-	},
-	then: {
-		$ref: "#"
-	},
-	"else": {
-		$ref: "#"
-	},
-	allOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	anyOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	oneOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	not: {
-		$ref: "#"
-	}
-};
-var require$$3 = {
+var require$$7 = {
 	$schema: $schema,
-	$id: $id,
+	$id: $id$2,
+	$vocabulary: $vocabulary,
+	$dynamicAnchor: $dynamicAnchor,
 	title: title$i,
-	definitions: definitions$3,
 	type: type$i,
 	properties: properties$h,
-	"default": true
+	$defs: $defs
 };
+
+Object.defineProperty(jsonSchema202012, "__esModule", { value: true });
+const metaSchema = require$$0;
+const applicator = require$$1;
+const unevaluated = require$$2;
+const content = require$$3;
+const core = require$$4;
+const format = require$$5;
+const metadata = require$$6;
+const validation = require$$7;
+const META_SUPPORT_DATA = ["/properties"];
+function addMetaSchema2020($data) {
+    [
+        metaSchema,
+        applicator,
+        unevaluated,
+        content,
+        core,
+        with$data(this, format),
+        metadata,
+        with$data(this, validation),
+    ].forEach((sch) => this.addMetaSchema(sch, undefined, false));
+    return this;
+    function with$data(ajv, sch) {
+        return $data ? ajv.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
+    }
+}
+jsonSchema202012.default = addMetaSchema2020;
 
 (function (module, exports) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
-const core_1 = core$2;
-const draft7_1 = draft7;
+const core_1 = core$3;
+const draft2020_1 = draft2020;
 const discriminator_1 = discriminator;
-const draft7MetaSchema = require$$3;
-const META_SUPPORT_DATA = ["/properties"];
-const META_SCHEMA_ID = "http://json-schema.org/draft-07/schema";
-class Ajv extends core_1.default {
+const json_schema_2020_12_1 = jsonSchema202012;
+const META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema";
+class Ajv2020 extends core_1.default {
+    constructor(opts = {}) {
+        super({
+            ...opts,
+            dynamicRef: true,
+            next: true,
+            unevaluated: true,
+        });
+    }
     _addVocabularies() {
         super._addVocabularies();
-        draft7_1.default.forEach((v) => this.addVocabulary(v));
+        draft2020_1.default.forEach((v) => this.addVocabulary(v));
         if (this.opts.discriminator)
             this.addKeyword(discriminator_1.default);
     }
     _addDefaultMetaSchema() {
         super._addDefaultMetaSchema();
-        if (!this.opts.meta)
+        const { $data, meta } = this.opts;
+        if (!meta)
             return;
-        const metaSchema = this.opts.$data
-            ? this.$dataMetaSchema(draft7MetaSchema, META_SUPPORT_DATA)
-            : draft7MetaSchema;
-        this.addMetaSchema(metaSchema, META_SCHEMA_ID, false);
+        json_schema_2020_12_1.default.call(this, $data);
         this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
     }
     defaultMeta() {
@@ -7118,9 +7737,9 @@ class Ajv extends core_1.default {
             super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : undefined));
     }
 }
-module.exports = exports = Ajv;
+module.exports = exports = Ajv2020;
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = Ajv;
+exports.default = Ajv2020;
 var validate_1 = validate;
 Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function () { return validate_1.KeywordCxt; } });
 var codegen_1 = codegen;
@@ -7131,12 +7750,16 @@ Object.defineProperty(exports, "nil", { enumerable: true, get: function () { ret
 Object.defineProperty(exports, "Name", { enumerable: true, get: function () { return codegen_1.Name; } });
 Object.defineProperty(exports, "CodeGen", { enumerable: true, get: function () { return codegen_1.CodeGen; } });
 
-}(ajv, ajv.exports));
+}(_2020, _2020.exports));
 
-var Ajv = /*@__PURE__*/getDefaultExportFromCjs(ajv.exports);
+var Ajv = /*@__PURE__*/getDefaultExportFromCjs(_2020.exports);
 
 const getValidation = (schema, example) => {
-    const ajv = new Ajv();
+    const ajv = new Ajv({
+        strict: "log",
+        verbose: true,
+        strictSchema: "log"
+    });
     const validate = ajv.compile(schema);
     return validate(example);
 };
@@ -7147,9 +7770,16 @@ const isValidSchema = (schema, example) => {
     }
     return true;
 };
+const getValidationWithDependencies = (schema, dependencies, example) => {
+    // When dealing with multiple schemas, you need to make sure they are all loaded before trying to validate
+    // Currently, DeviceShadow depends on Config being loaded, so you would need to call addSchema with Config
+    const ajv = new Ajv();
+    const validate = ajv.addSchema(dependencies).compile(schema);
+    return validate(example);
+};
 
 var title$h = "Air Quality";
-var description$j = "Set configuration values for the air quality module";
+var description$k = "Set configuration values for the air quality module";
 var type$h = "object";
 var properties$g = {
 	appId: {
@@ -7186,7 +7816,7 @@ var required$h = [
 var additionalProperties$g = false;
 var air_quality$1 = {
 	title: title$h,
-	description: description$j,
+	description: description$k,
 	type: type$h,
 	properties: properties$g,
 	required: required$h,
@@ -7196,7 +7826,7 @@ var air_quality$1 = {
 var AirQualityC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$h,
-	description: description$j,
+	description: description$k,
 	type: type$h,
 	properties: properties$g,
 	required: required$h,
@@ -7205,7 +7835,7 @@ var AirQualityC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$g = "Device";
-var description$i = "Request from the cloud for the device to gracefully disconnect";
+var description$j = "Request from the cloud for the device to gracefully disconnect";
 var type$g = "object";
 var properties$f = {
 	appId: {
@@ -7224,7 +7854,7 @@ var required$g = [
 var additionalProperties$f = false;
 var device$1 = {
 	title: title$g,
-	description: description$i,
+	description: description$j,
 	type: type$g,
 	properties: properties$f,
 	required: required$g,
@@ -7234,7 +7864,7 @@ var device$1 = {
 var DeviceC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$g,
-	description: description$i,
+	description: description$j,
 	type: type$g,
 	properties: properties$f,
 	required: required$g,
@@ -7243,7 +7873,7 @@ var DeviceC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$f = "Environmental Settings";
-var description$h = "The environmental sensors module settings";
+var description$i = "The environmental sensors module settings";
 var type$f = "object";
 var properties$e = {
 	appId: {
@@ -7273,7 +7903,7 @@ var required$f = [
 var additionalProperties$e = false;
 var env = {
 	title: title$f,
-	description: description$h,
+	description: description$i,
 	type: type$f,
 	properties: properties$e,
 	required: required$f,
@@ -7283,7 +7913,7 @@ var env = {
 var EnvC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$f,
-	description: description$h,
+	description: description$i,
 	type: type$f,
 	properties: properties$e,
 	required: required$f,
@@ -7292,7 +7922,7 @@ var EnvC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$e = "GPS Configuration";
-var description$g = "Sets configuration values for the GPS module";
+var description$h = "Sets configuration values for the GPS module";
 var type$e = "object";
 var properties$d = {
 	appId: {
@@ -7325,7 +7955,7 @@ var required$e = [
 ];
 var gps$1 = {
 	title: title$e,
-	description: description$g,
+	description: description$h,
 	type: type$e,
 	properties: properties$d,
 	additionalProperties: additionalProperties$d,
@@ -7335,7 +7965,7 @@ var gps$1 = {
 var GPSC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$e,
-	description: description$g,
+	description: description$h,
 	type: type$e,
 	properties: properties$d,
 	additionalProperties: additionalProperties$d,
@@ -7344,7 +7974,7 @@ var GPSC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$d = "LED";
-var description$f = "Sets configuration of the device's LED";
+var description$g = "Sets configuration of the device's LED";
 var type$d = "object";
 var properties$c = {
 	appId: {
@@ -7375,7 +8005,7 @@ var required$d = [
 var additionalProperties$c = false;
 var led = {
 	title: title$d,
-	description: description$f,
+	description: description$g,
 	type: type$d,
 	properties: properties$c,
 	required: required$d,
@@ -7385,7 +8015,7 @@ var led = {
 var LEDC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$d,
-	description: description$f,
+	description: description$g,
 	type: type$d,
 	properties: properties$c,
 	required: required$d,
@@ -7394,7 +8024,7 @@ var LEDC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$c = "Light";
-var description$e = "Sets configuration values for the light sensor module";
+var description$f = "Sets configuration values for the light sensor module";
 var type$c = "object";
 var properties$b = {
 	appId: {
@@ -7428,7 +8058,7 @@ var required$c = [
 ];
 var light$1 = {
 	title: title$c,
-	description: description$e,
+	description: description$f,
 	type: type$c,
 	properties: properties$b,
 	additionalProperties: additionalProperties$b,
@@ -7438,7 +8068,7 @@ var light$1 = {
 var LightC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$c,
-	description: description$e,
+	description: description$f,
 	type: type$c,
 	properties: properties$b,
 	additionalProperties: additionalProperties$b,
@@ -7447,7 +8077,7 @@ var LightC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$b = "Modem";
-var description$d = "IP device modem information";
+var description$e = "IP device modem information";
 var type$b = "object";
 var additionalProperties$a = false;
 var properties$a = {
@@ -7474,7 +8104,7 @@ var required$b = [
 ];
 var modem = {
 	title: title$b,
-	description: description$d,
+	description: description$e,
 	type: type$b,
 	additionalProperties: additionalProperties$a,
 	properties: properties$a,
@@ -7484,7 +8114,7 @@ var modem = {
 var ModemC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$b,
-	description: description$d,
+	description: description$e,
 	type: type$b,
 	additionalProperties: additionalProperties$a,
 	properties: properties$a,
@@ -7493,7 +8123,7 @@ var ModemC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$a = "Temperature";
-var description$c = "Sets configuration values for the temperature module";
+var description$d = "Sets configuration values for the temperature module";
 var type$a = "object";
 var properties$9 = {
 	appId: {
@@ -7530,7 +8160,7 @@ var required$a = [
 ];
 var temp$1 = {
 	title: title$a,
-	description: description$c,
+	description: description$d,
 	type: type$a,
 	properties: properties$9,
 	additionalProperties: additionalProperties$9,
@@ -7540,7 +8170,7 @@ var temp$1 = {
 var TemperatureC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$a,
-	description: description$c,
+	description: description$d,
 	type: type$a,
 	properties: properties$9,
 	additionalProperties: additionalProperties$9,
@@ -7548,9 +8178,9 @@ var TemperatureC2D = /*#__PURE__*/Object.freeze({
 	'default': temp$1
 });
 
-var description$b = "The desired and reported state of a BLE Gateway device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
-var $ref$1 = "#/definitions/DeviceShadowIP";
-var definitions$2 = {
+var description$c = "The desired and reported state of a BLE Gateway device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
+var $ref$2 = "#/definitions/DeviceShadowIP";
+var definitions$3 = {
 	DeviceShadowIP: {
 		type: "object",
 		additionalProperties: false,
@@ -7683,22 +8313,23 @@ var definitions$2 = {
 	}
 };
 var gatewayShadow = {
-	description: description$b,
-	$ref: $ref$1,
-	definitions: definitions$2
+	description: description$c,
+	$ref: $ref$2,
+	definitions: definitions$3
 };
 
 var Gateway = /*#__PURE__*/Object.freeze({
 	__proto__: null,
-	description: description$b,
-	$ref: $ref$1,
-	definitions: definitions$2,
+	description: description$c,
+	$ref: $ref$2,
+	definitions: definitions$3,
 	'default': gatewayShadow
 });
 
-var description$a = "The desired and reported state of an IP device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
-var $ref = "#/definitions/DeviceShadowIP";
-var definitions$1 = {
+var $id$1 = "/ipShadow.json";
+var description$b = "The desired and reported state of an IP device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
+var $ref$1 = "#/definitions/DeviceShadowIP";
+var definitions$2 = {
 	DeviceShadowIP: {
 		type: "object",
 		additionalProperties: false,
@@ -7728,7 +8359,7 @@ var definitions$1 = {
 				type: "string"
 			},
 			config: {
-				$ref: "#/definitions/Config"
+				$ref: "config.json#/definitions/Config"
 			}
 		},
 		required: [
@@ -7755,7 +8386,7 @@ var definitions$1 = {
 				$ref: "#/definitions/Device"
 			},
 			config: {
-				$ref: "#/definitions/Config"
+				$ref: "config.json#/definitions/Config"
 			}
 		},
 		required: [
@@ -7809,29 +8440,6 @@ var definitions$1 = {
 			"d2c"
 		],
 		title: "Topics"
-	},
-	Config: {
-		type: "object",
-		description: "Client set device configuration.",
-		properties: {
-			GPS: {
-				$ref: "#/definitions/Gps"
-			}
-		},
-		title: "Config"
-	},
-	Gps: {
-		type: "object",
-		description: "Enable GPS",
-		properties: {
-			enable: {
-				type: "boolean"
-			}
-		},
-		required: [
-			"enable"
-		],
-		title: "Gps"
 	},
 	Connection: {
 		type: "object",
@@ -8035,17 +8643,63 @@ var definitions$1 = {
 	}
 };
 var ipShadow = {
+	$id: $id$1,
+	description: description$b,
+	$ref: $ref$1,
+	definitions: definitions$2
+};
+
+var IP = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	$id: $id$1,
+	description: description$b,
+	$ref: $ref$1,
+	definitions: definitions$2,
+	'default': ipShadow
+});
+
+var $id = "/config.json";
+var description$a = "The reported config within the AWS IoT Shadow.";
+var $ref = "#/definitions/Config";
+var definitions$1 = {
+	Config: {
+		type: "object",
+		description: "Client set device configuration.",
+		properties: {
+			GPS: {
+				$ref: "#/definitions/Gps"
+			}
+		},
+		title: "Config"
+	},
+	Gps: {
+		type: "object",
+		description: "Enable GPS",
+		properties: {
+			enable: {
+				type: "boolean"
+			}
+		},
+		required: [
+			"enable"
+		],
+		title: "Gps"
+	}
+};
+var config = {
+	$id: $id,
 	description: description$a,
 	$ref: $ref,
 	definitions: definitions$1
 };
 
-var IP = /*#__PURE__*/Object.freeze({
+var Config = /*#__PURE__*/Object.freeze({
 	__proto__: null,
+	$id: $id,
 	description: description$a,
 	$ref: $ref,
 	definitions: definitions$1,
-	'default': ipShadow
+	'default': config
 });
 
 var title$9 = "Air pressure";
@@ -8062,7 +8716,7 @@ var properties$8 = {
 	},
 	data: {
 		type: "string",
-		pattern: "^([0-9]|[1-9][0-9]+)\\.[0-9]+$"
+		pattern: "^([0-9]|[1-9][0-9]+)(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8506,7 +9160,7 @@ var oneOf = [
 			data: {
 				type: "string",
 				description: "NEMA string",
-				pattern: "^\\$(GPGGA|GPGLL|GPGSA|GPGSV|GPRMC|GPVTG)(,[0-9A-Z\\*\\.]*)+$"
+				pattern: "^\\$(GPGGA|GPGLL|GPGSA|GPGSV|GPRMC|GPVTG)(,[0-9A-Z\\*\\.]*)+\n?$"
 			},
 			ts: {
 				type: "number",
@@ -8557,7 +9211,7 @@ var properties$3 = {
 	data: {
 		type: "string",
 		description: "Relative humidity percentage",
-		pattern: "^(([0-9]|[1-9][0-9])\\.[0-9])|100.0$"
+		pattern: "^(([0-9]|[1-9][0-9])(\\.[0-9])?)|100\\.0|100$"
 	},
 	ts: {
 		type: "number",
@@ -8661,7 +9315,7 @@ var properties$1 = {
 	data: {
 		type: "string",
 		description: "RSRP dBm string",
-		pattern: "^-[0-9]+.[0-9]+$"
+		pattern: "^-[0-9]+(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8715,7 +9369,7 @@ var properties = {
 	},
 	data: {
 		type: "string",
-		pattern: "^-?([0-9]|[1-9][0-9]+)\\.[0-9]+$"
+		pattern: "^-?([0-9]|[1-9][0-9]+)(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8765,6 +9419,7 @@ const CloudToGateway = {};
 const DeviceShadow = {
     Gateway,
     IP,
+    Config,
 };
 const DeviceToCloud = {
     AirPress: AirPressD2C,
@@ -8784,4 +9439,5 @@ exports.CloudToGateway = CloudToGateway;
 exports.DeviceShadow = DeviceShadow;
 exports.DeviceToCloud = DeviceToCloud;
 exports.getValidation = getValidation;
+exports.getValidationWithDependencies = getValidationWithDependencies;
 exports.isValidSchema = isValidSchema;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -4,9 +4,9 @@ function getDefaultExportFromCjs (x) {
 	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
-var ajv = {exports: {}};
+var _2020 = {exports: {}};
 
-var core$2 = {};
+var core$3 = {};
 
 var validate = {};
 
@@ -221,11 +221,11 @@ class ValueScopeName extends code_1.Name {
     }
     setValue(value, { property, itemIndex }) {
         this.value = value;
-        this.scopePath = code_1._ `.${new code_1.Name(property)}[${itemIndex}]`;
+        this.scopePath = (0, code_1._) `.${new code_1.Name(property)}[${itemIndex}]`;
     }
 }
 exports.ValueScopeName = ValueScopeName;
-const line = code_1._ `\n`;
+const line = (0, code_1._) `\n`;
 class ValueScope extends Scope {
     constructor(opts) {
         super(opts);
@@ -272,7 +272,7 @@ class ValueScope extends Scope {
         return this._reduceValues(values, (name) => {
             if (name.scopePath === undefined)
                 throw new Error(`CodeGen: name "${name}" has no value`);
-            return code_1._ `${scopeName}${name.scopePath}`;
+            return (0, code_1._) `${scopeName}${name.scopePath}`;
         });
     }
     scopeCode(values = this._values, usedValues, getCode) {
@@ -296,10 +296,10 @@ class ValueScope extends Scope {
                 let c = valueCode(name);
                 if (c) {
                     const def = this.opts.es5 ? exports.varKinds.var : exports.varKinds.const;
-                    code = code_1._ `${code}${def} ${name} = ${c};${this.opts._n}`;
+                    code = (0, code_1._) `${code}${def} ${name} = ${c};${this.opts._n}`;
                 }
                 else if ((c = getCode === null || getCode === void 0 ? void 0 : getCode(name))) {
-                    code = code_1._ `${code}${c}${this.opts._n}`;
+                    code = (0, code_1._) `${code}${c}${this.opts._n}`;
                 }
                 else {
                     throw new ValueError(name);
@@ -766,7 +766,7 @@ class CodeGen {
             code.push(key);
             if (key !== value || this.opts.es5) {
                 code.push(":");
-                code_1.addCodeArg(code, value);
+                (0, code_1.addCodeArg)(code, value);
             }
         }
         code.push("}");
@@ -818,8 +818,8 @@ class CodeGen {
         const name = this._scope.toName(nameOrPrefix);
         if (this.opts.es5) {
             const arr = iterable instanceof code_1.Name ? iterable : this.var("_arr", iterable);
-            return this.forRange("_i", 0, code_1._ `${arr}.length`, (i) => {
-                this.var(name, code_1._ `${arr}[${i}]`);
+            return this.forRange("_i", 0, (0, code_1._) `${arr}.length`, (i) => {
+                this.var(name, (0, code_1._) `${arr}[${i}]`);
                 forBody(name);
             });
         }
@@ -829,7 +829,7 @@ class CodeGen {
     // With option `ownProperties` replaced with a `for-of` loop for object keys
     forIn(nameOrPrefix, obj, forBody, varKind = this.opts.es5 ? scope_1.varKinds.var : scope_1.varKinds.const) {
         if (this.opts.ownProperties) {
-            return this.forOf(nameOrPrefix, code_1._ `Object.keys(${obj})`, forBody);
+            return this.forOf(nameOrPrefix, (0, code_1._) `Object.keys(${obj})`, forBody);
         }
         const name = this._scope.toName(nameOrPrefix);
         return this._for(new ForIter("in", varKind, name, obj), () => forBody(name));
@@ -989,7 +989,7 @@ function subtractNames(names, from) {
         names[n] = (names[n] || 0) - (from[n] || 0);
 }
 function not(x) {
-    return typeof x == "boolean" || typeof x == "number" || x === null ? !x : code_1._ `!${par(x)}`;
+    return typeof x == "boolean" || typeof x == "number" || x === null ? !x : (0, code_1._) `!${par(x)}`;
 }
 exports.not = not;
 const andCode = mappend(exports.operators.AND);
@@ -1005,10 +1005,10 @@ function or(...args) {
 }
 exports.or = or;
 function mappend(op) {
-    return (x, y) => (x === code_1.nil ? y : y === code_1.nil ? x : code_1._ `${par(x)} ${op} ${par(y)}`);
+    return (x, y) => (x === code_1.nil ? y : y === code_1.nil ? x : (0, code_1._) `${par(x)} ${op} ${par(y)}`);
 }
 function par(x) {
-    return x instanceof code_1.Name ? x : code_1._ `(${x})`;
+    return x instanceof code_1.Name ? x : (0, code_1._) `(${x})`;
 }
 
 }(codegen));
@@ -1073,9 +1073,9 @@ function schemaRefOrVal({ topSchemaRef, schemaPath }, schema, keyword, $data) {
         if (typeof schema == "number" || typeof schema == "boolean")
             return schema;
         if (typeof schema == "string")
-            return codegen_1._ `${schema}`;
+            return (0, codegen_1._) `${schema}`;
     }
-    return codegen_1._ `${topSchemaRef}${schemaPath}${codegen_1.getProperty(keyword)}`;
+    return (0, codegen_1._) `${topSchemaRef}${schemaPath}${(0, codegen_1.getProperty)(keyword)}`;
 }
 exports.schemaRefOrVal = schemaRefOrVal;
 function unescapeFragment(str) {
@@ -1120,15 +1120,15 @@ function makeMergeEvaluated({ mergeNames, mergeToName, mergeValues, resultToName
 }
 exports.mergeEvaluated = {
     props: makeMergeEvaluated({
-        mergeNames: (gen, from, to) => gen.if(codegen_1._ `${to} !== true && ${from} !== undefined`, () => {
-            gen.if(codegen_1._ `${from} === true`, () => gen.assign(to, true), () => gen.assign(to, codegen_1._ `${to} || {}`).code(codegen_1._ `Object.assign(${to}, ${from})`));
+        mergeNames: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true && ${from} !== undefined`, () => {
+            gen.if((0, codegen_1._) `${from} === true`, () => gen.assign(to, true), () => gen.assign(to, (0, codegen_1._) `${to} || {}`).code((0, codegen_1._) `Object.assign(${to}, ${from})`));
         }),
-        mergeToName: (gen, from, to) => gen.if(codegen_1._ `${to} !== true`, () => {
+        mergeToName: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true`, () => {
             if (from === true) {
                 gen.assign(to, true);
             }
             else {
-                gen.assign(to, codegen_1._ `${to} || {}`);
+                gen.assign(to, (0, codegen_1._) `${to} || {}`);
                 setEvaluated(gen, to, from);
             }
         }),
@@ -1136,8 +1136,8 @@ exports.mergeEvaluated = {
         resultToName: evaluatedPropsToName,
     }),
     items: makeMergeEvaluated({
-        mergeNames: (gen, from, to) => gen.if(codegen_1._ `${to} !== true && ${from} !== undefined`, () => gen.assign(to, codegen_1._ `${from} === true ? true : ${to} > ${from} ? ${to} : ${from}`)),
-        mergeToName: (gen, from, to) => gen.if(codegen_1._ `${to} !== true`, () => gen.assign(to, from === true ? true : codegen_1._ `${to} > ${from} ? ${to} : ${from}`)),
+        mergeNames: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true && ${from} !== undefined`, () => gen.assign(to, (0, codegen_1._) `${from} === true ? true : ${to} > ${from} ? ${to} : ${from}`)),
+        mergeToName: (gen, from, to) => gen.if((0, codegen_1._) `${to} !== true`, () => gen.assign(to, from === true ? true : (0, codegen_1._) `${to} > ${from} ? ${to} : ${from}`)),
         mergeValues: (from, to) => (from === true ? true : Math.max(from, to)),
         resultToName: (gen, items) => gen.var("items", items),
     }),
@@ -1145,14 +1145,14 @@ exports.mergeEvaluated = {
 function evaluatedPropsToName(gen, ps) {
     if (ps === true)
         return gen.var("props", true);
-    const props = gen.var("props", codegen_1._ `{}`);
+    const props = gen.var("props", (0, codegen_1._) `{}`);
     if (ps !== undefined)
         setEvaluated(gen, props, ps);
     return props;
 }
 exports.evaluatedPropsToName = evaluatedPropsToName;
 function setEvaluated(gen, props, ps) {
-    Object.keys(ps).forEach((p) => gen.assign(codegen_1._ `${props}${codegen_1.getProperty(p)}`, true));
+    Object.keys(ps).forEach((p) => gen.assign((0, codegen_1._) `${props}${(0, codegen_1.getProperty)(p)}`, true));
 }
 exports.setEvaluated = setEvaluated;
 const snippets = {};
@@ -1174,13 +1174,13 @@ function getErrorPath(dataProp, dataPropType, jsPropertySyntax) {
         const isNumber = dataPropType === Type.Num;
         return jsPropertySyntax
             ? isNumber
-                ? codegen_1._ `"[" + ${dataProp} + "]"`
-                : codegen_1._ `"['" + ${dataProp} + "']"`
+                ? (0, codegen_1._) `"[" + ${dataProp} + "]"`
+                : (0, codegen_1._) `"['" + ${dataProp} + "']"`
             : isNumber
-                ? codegen_1._ `"/" + ${dataProp}`
-                : codegen_1._ `"/" + ${dataProp}.replace(/~/g, "~0").replace(/\\//g, "~1")`; // TODO maybe use global escapePointer
+                ? (0, codegen_1._) `"/" + ${dataProp}`
+                : (0, codegen_1._) `"/" + ${dataProp}.replace(/~/g, "~0").replace(/\\//g, "~1")`; // TODO maybe use global escapePointer
     }
-    return jsPropertySyntax ? codegen_1.getProperty(dataProp).toString() : "/" + escapeJsonPointer(dataProp);
+    return jsPropertySyntax ? (0, codegen_1.getProperty)(dataProp).toString() : "/" + escapeJsonPointer(dataProp);
 }
 exports.getErrorPath = getErrorPath;
 function checkStrictMode(it, msg, mode = it.opts.strictSchema) {
@@ -1198,29 +1198,29 @@ exports.checkStrictMode = checkStrictMode;
 var names$1 = {};
 
 Object.defineProperty(names$1, "__esModule", { value: true });
-const codegen_1$t = codegen;
+const codegen_1$x = codegen;
 const names = {
     // validation function arguments
-    data: new codegen_1$t.Name("data"),
+    data: new codegen_1$x.Name("data"),
     // args passed from referencing schema
-    valCxt: new codegen_1$t.Name("valCxt"),
-    instancePath: new codegen_1$t.Name("instancePath"),
-    parentData: new codegen_1$t.Name("parentData"),
-    parentDataProperty: new codegen_1$t.Name("parentDataProperty"),
-    rootData: new codegen_1$t.Name("rootData"),
-    dynamicAnchors: new codegen_1$t.Name("dynamicAnchors"),
+    valCxt: new codegen_1$x.Name("valCxt"),
+    instancePath: new codegen_1$x.Name("instancePath"),
+    parentData: new codegen_1$x.Name("parentData"),
+    parentDataProperty: new codegen_1$x.Name("parentDataProperty"),
+    rootData: new codegen_1$x.Name("rootData"),
+    dynamicAnchors: new codegen_1$x.Name("dynamicAnchors"),
     // function scoped variables
-    vErrors: new codegen_1$t.Name("vErrors"),
-    errors: new codegen_1$t.Name("errors"),
-    this: new codegen_1$t.Name("this"),
+    vErrors: new codegen_1$x.Name("vErrors"),
+    errors: new codegen_1$x.Name("errors"),
+    this: new codegen_1$x.Name("this"),
     // "globals"
-    self: new codegen_1$t.Name("self"),
-    scope: new codegen_1$t.Name("scope"),
+    self: new codegen_1$x.Name("self"),
+    scope: new codegen_1$x.Name("scope"),
     // JTD serialize/parse name for JSON string and position
-    json: new codegen_1$t.Name("json"),
-    jsonPos: new codegen_1$t.Name("jsonPos"),
-    jsonLen: new codegen_1$t.Name("jsonLen"),
-    jsonPart: new codegen_1$t.Name("jsonPart"),
+    json: new codegen_1$x.Name("json"),
+    jsonPos: new codegen_1$x.Name("jsonPos"),
+    jsonLen: new codegen_1$x.Name("jsonLen"),
+    jsonPart: new codegen_1$x.Name("jsonPart"),
 };
 names$1.default = names;
 
@@ -1231,12 +1231,12 @@ const codegen_1 = codegen;
 const util_1 = util;
 const names_1 = names$1;
 exports.keywordError = {
-    message: ({ keyword }) => codegen_1.str `should pass "${keyword}" keyword validation`,
+    message: ({ keyword }) => (0, codegen_1.str) `must pass "${keyword}" keyword validation`,
 };
 exports.keyword$DataError = {
     message: ({ keyword, schemaType }) => schemaType
-        ? codegen_1.str `"${keyword}" keyword must be ${schemaType} ($data)`
-        : codegen_1.str `"${keyword}" keyword is invalid ($data)`,
+        ? (0, codegen_1.str) `"${keyword}" keyword must be ${schemaType} ($data)`
+        : (0, codegen_1.str) `"${keyword}" keyword is invalid ($data)`,
 };
 function reportError(cxt, error = exports.keywordError, errorPaths, overrideAllErrors) {
     const { it } = cxt;
@@ -1246,7 +1246,7 @@ function reportError(cxt, error = exports.keywordError, errorPaths, overrideAllE
         addError(gen, errObj);
     }
     else {
-        returnErrors(it, codegen_1._ `[${errObj}]`);
+        returnErrors(it, (0, codegen_1._) `[${errObj}]`);
     }
 }
 exports.reportError = reportError;
@@ -1262,7 +1262,7 @@ function reportExtraError(cxt, error = exports.keywordError, errorPaths) {
 exports.reportExtraError = reportExtraError;
 function resetErrorsCount(gen, errsCount) {
     gen.assign(names_1.default.errors, errsCount);
-    gen.if(codegen_1._ `${names_1.default.vErrors} !== null`, () => gen.if(errsCount, () => gen.assign(codegen_1._ `${names_1.default.vErrors}.length`, errsCount), () => gen.assign(names_1.default.vErrors, null)));
+    gen.if((0, codegen_1._) `${names_1.default.vErrors} !== null`, () => gen.if(errsCount, () => gen.assign((0, codegen_1._) `${names_1.default.vErrors}.length`, errsCount), () => gen.assign(names_1.default.vErrors, null)));
 }
 exports.resetErrorsCount = resetErrorsCount;
 function extendErrors({ gen, keyword, schemaValue, data, errsCount, it, }) {
@@ -1271,28 +1271,28 @@ function extendErrors({ gen, keyword, schemaValue, data, errsCount, it, }) {
         throw new Error("ajv implementation error");
     const err = gen.name("err");
     gen.forRange("i", errsCount, names_1.default.errors, (i) => {
-        gen.const(err, codegen_1._ `${names_1.default.vErrors}[${i}]`);
-        gen.if(codegen_1._ `${err}.instancePath === undefined`, () => gen.assign(codegen_1._ `${err}.instancePath`, codegen_1.strConcat(names_1.default.instancePath, it.errorPath)));
-        gen.assign(codegen_1._ `${err}.schemaPath`, codegen_1.str `${it.errSchemaPath}/${keyword}`);
+        gen.const(err, (0, codegen_1._) `${names_1.default.vErrors}[${i}]`);
+        gen.if((0, codegen_1._) `${err}.instancePath === undefined`, () => gen.assign((0, codegen_1._) `${err}.instancePath`, (0, codegen_1.strConcat)(names_1.default.instancePath, it.errorPath)));
+        gen.assign((0, codegen_1._) `${err}.schemaPath`, (0, codegen_1.str) `${it.errSchemaPath}/${keyword}`);
         if (it.opts.verbose) {
-            gen.assign(codegen_1._ `${err}.schema`, schemaValue);
-            gen.assign(codegen_1._ `${err}.data`, data);
+            gen.assign((0, codegen_1._) `${err}.schema`, schemaValue);
+            gen.assign((0, codegen_1._) `${err}.data`, data);
         }
     });
 }
 exports.extendErrors = extendErrors;
 function addError(gen, errObj) {
     const err = gen.const("err", errObj);
-    gen.if(codegen_1._ `${names_1.default.vErrors} === null`, () => gen.assign(names_1.default.vErrors, codegen_1._ `[${err}]`), codegen_1._ `${names_1.default.vErrors}.push(${err})`);
-    gen.code(codegen_1._ `${names_1.default.errors}++`);
+    gen.if((0, codegen_1._) `${names_1.default.vErrors} === null`, () => gen.assign(names_1.default.vErrors, (0, codegen_1._) `[${err}]`), (0, codegen_1._) `${names_1.default.vErrors}.push(${err})`);
+    gen.code((0, codegen_1._) `${names_1.default.errors}++`);
 }
 function returnErrors(it, errs) {
     const { gen, validateName, schemaEnv } = it;
     if (schemaEnv.$async) {
-        gen.throw(codegen_1._ `new ${it.ValidationError}(${errs})`);
+        gen.throw((0, codegen_1._) `new ${it.ValidationError}(${errs})`);
     }
     else {
-        gen.assign(codegen_1._ `${validateName}.errors`, errs);
+        gen.assign((0, codegen_1._) `${validateName}.errors`, errs);
         gen.return(false);
     }
 }
@@ -1308,7 +1308,7 @@ const E = {
 function errorObjectCode(cxt, error, errorPaths) {
     const { createErrors } = cxt.it;
     if (createErrors === false)
-        return codegen_1._ `{}`;
+        return (0, codegen_1._) `{}`;
     return errorObject(cxt, error, errorPaths);
 }
 function errorObject(cxt, error, errorPaths = {}) {
@@ -1322,26 +1322,26 @@ function errorObject(cxt, error, errorPaths = {}) {
 }
 function errorInstancePath({ errorPath }, { instancePath }) {
     const instPath = instancePath
-        ? codegen_1.str `${errorPath}${util_1.getErrorPath(instancePath, util_1.Type.Str)}`
+        ? (0, codegen_1.str) `${errorPath}${(0, util_1.getErrorPath)(instancePath, util_1.Type.Str)}`
         : errorPath;
-    return [names_1.default.instancePath, codegen_1.strConcat(names_1.default.instancePath, instPath)];
+    return [names_1.default.instancePath, (0, codegen_1.strConcat)(names_1.default.instancePath, instPath)];
 }
 function errorSchemaPath({ keyword, it: { errSchemaPath } }, { schemaPath, parentSchema }) {
-    let schPath = parentSchema ? errSchemaPath : codegen_1.str `${errSchemaPath}/${keyword}`;
+    let schPath = parentSchema ? errSchemaPath : (0, codegen_1.str) `${errSchemaPath}/${keyword}`;
     if (schemaPath) {
-        schPath = codegen_1.str `${schPath}${util_1.getErrorPath(schemaPath, util_1.Type.Str)}`;
+        schPath = (0, codegen_1.str) `${schPath}${(0, util_1.getErrorPath)(schemaPath, util_1.Type.Str)}`;
     }
     return [E.schemaPath, schPath];
 }
 function extraErrorProps(cxt, { params, message }, keyValues) {
     const { keyword, data, schemaValue, it } = cxt;
     const { opts, propertyName, topSchemaRef, schemaPath } = it;
-    keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || codegen_1._ `{}`]);
+    keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || (0, codegen_1._) `{}`]);
     if (opts.messages) {
         keyValues.push([E.message, typeof message == "function" ? message(cxt) : message]);
     }
     if (opts.verbose) {
-        keyValues.push([E.schema, schemaValue], [E.parentSchema, codegen_1._ `${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
+        keyValues.push([E.schema, schemaValue], [E.parentSchema, (0, codegen_1._) `${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
     }
     if (propertyName)
         keyValues.push([E.propertyName, propertyName]);
@@ -1352,8 +1352,8 @@ function extraErrorProps(cxt, { params, message }, keyValues) {
 Object.defineProperty(boolSchema, "__esModule", { value: true });
 boolSchema.boolOrEmptySchema = boolSchema.topBoolOrEmptySchema = void 0;
 const errors_1$2 = errors;
-const codegen_1$s = codegen;
-const names_1$6 = names$1;
+const codegen_1$w = codegen;
+const names_1$9 = names$1;
 const boolError = {
     message: "boolean schema is false",
 };
@@ -1363,10 +1363,10 @@ function topBoolOrEmptySchema(it) {
         falseSchemaError(it, false);
     }
     else if (typeof schema == "object" && schema.$async === true) {
-        gen.return(names_1$6.default.data);
+        gen.return(names_1$9.default.data);
     }
     else {
-        gen.assign(codegen_1$s._ `${validateName}.errors`, null);
+        gen.assign((0, codegen_1$w._) `${validateName}.errors`, null);
         gen.return(true);
     }
 }
@@ -1395,7 +1395,7 @@ function falseSchemaError(it, overrideAllErrors) {
         params: {},
         it,
     };
-    errors_1$2.reportError(cxt, boolError, undefined, overrideAllErrors);
+    (0, errors_1$2.reportError)(cxt, boolError, undefined, overrideAllErrors);
 }
 
 var dataType = {};
@@ -1488,7 +1488,7 @@ function coerceAndCheckDataType(it, types) {
     const { gen, data, opts } = it;
     const coerceTo = coerceToTypes(types, opts.coerceTypes);
     const checkTypes = types.length > 0 &&
-        !(coerceTo.length === 0 && types.length === 1 && applicability_1.schemaHasRulesForType(it, types[0]));
+        !(coerceTo.length === 0 && types.length === 1 && (0, applicability_1.schemaHasRulesForType)(it, types[0]));
     if (checkTypes) {
         const wrongType = checkDataTypes(types, data, opts.strictNumbers, DataType.Wrong);
         gen.if(wrongType, () => {
@@ -1509,15 +1509,15 @@ function coerceToTypes(types, coerceTypes) {
 }
 function coerceData(it, types, coerceTo) {
     const { gen, data, opts } = it;
-    const dataType = gen.let("dataType", codegen_1._ `typeof ${data}`);
-    const coerced = gen.let("coerced", codegen_1._ `undefined`);
+    const dataType = gen.let("dataType", (0, codegen_1._) `typeof ${data}`);
+    const coerced = gen.let("coerced", (0, codegen_1._) `undefined`);
     if (opts.coerceTypes === "array") {
-        gen.if(codegen_1._ `${dataType} == 'object' && Array.isArray(${data}) && ${data}.length == 1`, () => gen
-            .assign(data, codegen_1._ `${data}[0]`)
-            .assign(dataType, codegen_1._ `typeof ${data}`)
+        gen.if((0, codegen_1._) `${dataType} == 'object' && Array.isArray(${data}) && ${data}.length == 1`, () => gen
+            .assign(data, (0, codegen_1._) `${data}[0]`)
+            .assign(dataType, (0, codegen_1._) `typeof ${data}`)
             .if(checkDataTypes(types, data, opts.strictNumbers), () => gen.assign(coerced, data)));
     }
-    gen.if(codegen_1._ `${coerced} !== undefined`);
+    gen.if((0, codegen_1._) `${coerced} !== undefined`);
     for (const t of coerceTo) {
         if (COERCIBLE.has(t) || (t === "array" && opts.coerceTypes === "array")) {
             coerceSpecificType(t);
@@ -1526,7 +1526,7 @@ function coerceData(it, types, coerceTo) {
     gen.else();
     reportTypeError(it);
     gen.endIf();
-    gen.if(codegen_1._ `${coerced} !== undefined`, () => {
+    gen.if((0, codegen_1._) `${coerced} !== undefined`, () => {
         gen.assign(data, coerced);
         assignParentData(it, coerced);
     });
@@ -1534,70 +1534,70 @@ function coerceData(it, types, coerceTo) {
         switch (t) {
             case "string":
                 gen
-                    .elseIf(codegen_1._ `${dataType} == "number" || ${dataType} == "boolean"`)
-                    .assign(coerced, codegen_1._ `"" + ${data}`)
-                    .elseIf(codegen_1._ `${data} === null`)
-                    .assign(coerced, codegen_1._ `""`);
+                    .elseIf((0, codegen_1._) `${dataType} == "number" || ${dataType} == "boolean"`)
+                    .assign(coerced, (0, codegen_1._) `"" + ${data}`)
+                    .elseIf((0, codegen_1._) `${data} === null`)
+                    .assign(coerced, (0, codegen_1._) `""`);
                 return;
             case "number":
                 gen
-                    .elseIf(codegen_1._ `${dataType} == "boolean" || ${data} === null
+                    .elseIf((0, codegen_1._) `${dataType} == "boolean" || ${data} === null
               || (${dataType} == "string" && ${data} && ${data} == +${data})`)
-                    .assign(coerced, codegen_1._ `+${data}`);
+                    .assign(coerced, (0, codegen_1._) `+${data}`);
                 return;
             case "integer":
                 gen
-                    .elseIf(codegen_1._ `${dataType} === "boolean" || ${data} === null
+                    .elseIf((0, codegen_1._) `${dataType} === "boolean" || ${data} === null
               || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1))`)
-                    .assign(coerced, codegen_1._ `+${data}`);
+                    .assign(coerced, (0, codegen_1._) `+${data}`);
                 return;
             case "boolean":
                 gen
-                    .elseIf(codegen_1._ `${data} === "false" || ${data} === 0 || ${data} === null`)
+                    .elseIf((0, codegen_1._) `${data} === "false" || ${data} === 0 || ${data} === null`)
                     .assign(coerced, false)
-                    .elseIf(codegen_1._ `${data} === "true" || ${data} === 1`)
+                    .elseIf((0, codegen_1._) `${data} === "true" || ${data} === 1`)
                     .assign(coerced, true);
                 return;
             case "null":
-                gen.elseIf(codegen_1._ `${data} === "" || ${data} === 0 || ${data} === false`);
+                gen.elseIf((0, codegen_1._) `${data} === "" || ${data} === 0 || ${data} === false`);
                 gen.assign(coerced, null);
                 return;
             case "array":
                 gen
-                    .elseIf(codegen_1._ `${dataType} === "string" || ${dataType} === "number"
+                    .elseIf((0, codegen_1._) `${dataType} === "string" || ${dataType} === "number"
               || ${dataType} === "boolean" || ${data} === null`)
-                    .assign(coerced, codegen_1._ `[${data}]`);
+                    .assign(coerced, (0, codegen_1._) `[${data}]`);
         }
     }
 }
 function assignParentData({ gen, parentData, parentDataProperty }, expr) {
     // TODO use gen.property
-    gen.if(codegen_1._ `${parentData} !== undefined`, () => gen.assign(codegen_1._ `${parentData}[${parentDataProperty}]`, expr));
+    gen.if((0, codegen_1._) `${parentData} !== undefined`, () => gen.assign((0, codegen_1._) `${parentData}[${parentDataProperty}]`, expr));
 }
 function checkDataType(dataType, data, strictNums, correct = DataType.Correct) {
     const EQ = correct === DataType.Correct ? codegen_1.operators.EQ : codegen_1.operators.NEQ;
     let cond;
     switch (dataType) {
         case "null":
-            return codegen_1._ `${data} ${EQ} null`;
+            return (0, codegen_1._) `${data} ${EQ} null`;
         case "array":
-            cond = codegen_1._ `Array.isArray(${data})`;
+            cond = (0, codegen_1._) `Array.isArray(${data})`;
             break;
         case "object":
-            cond = codegen_1._ `${data} && typeof ${data} == "object" && !Array.isArray(${data})`;
+            cond = (0, codegen_1._) `${data} && typeof ${data} == "object" && !Array.isArray(${data})`;
             break;
         case "integer":
-            cond = numCond(codegen_1._ `!(${data} % 1) && !isNaN(${data})`);
+            cond = numCond((0, codegen_1._) `!(${data} % 1) && !isNaN(${data})`);
             break;
         case "number":
             cond = numCond();
             break;
         default:
-            return codegen_1._ `typeof ${data} ${EQ} ${dataType}`;
+            return (0, codegen_1._) `typeof ${data} ${EQ} ${dataType}`;
     }
-    return correct === DataType.Correct ? cond : codegen_1.not(cond);
+    return correct === DataType.Correct ? cond : (0, codegen_1.not)(cond);
     function numCond(_cond = codegen_1.nil) {
-        return codegen_1.and(codegen_1._ `typeof ${data} == "number"`, _cond, strictNums ? codegen_1._ `isFinite(${data})` : codegen_1.nil);
+        return (0, codegen_1.and)((0, codegen_1._) `typeof ${data} == "number"`, _cond, strictNums ? (0, codegen_1._) `isFinite(${data})` : codegen_1.nil);
     }
 }
 exports.checkDataType = checkDataType;
@@ -1606,10 +1606,10 @@ function checkDataTypes(dataTypes, data, strictNums, correct) {
         return checkDataType(dataTypes[0], data, strictNums, correct);
     }
     let cond;
-    const types = util_1.toHash(dataTypes);
+    const types = (0, util_1.toHash)(dataTypes);
     if (types.array && types.object) {
-        const notObj = codegen_1._ `typeof ${data} != "object"`;
-        cond = types.null ? notObj : codegen_1._ `!${data} || ${notObj}`;
+        const notObj = (0, codegen_1._) `typeof ${data} != "object"`;
+        cond = types.null ? notObj : (0, codegen_1._) `!${data} || ${notObj}`;
         delete types.null;
         delete types.array;
         delete types.object;
@@ -1620,22 +1620,22 @@ function checkDataTypes(dataTypes, data, strictNums, correct) {
     if (types.number)
         delete types.integer;
     for (const t in types)
-        cond = codegen_1.and(cond, checkDataType(t, data, strictNums, correct));
+        cond = (0, codegen_1.and)(cond, checkDataType(t, data, strictNums, correct));
     return cond;
 }
 exports.checkDataTypes = checkDataTypes;
 const typeError = {
     message: ({ schema }) => `must be ${schema}`,
-    params: ({ schema, schemaValue }) => typeof schema == "string" ? codegen_1._ `{type: ${schema}}` : codegen_1._ `{type: ${schemaValue}}`,
+    params: ({ schema, schemaValue }) => typeof schema == "string" ? (0, codegen_1._) `{type: ${schema}}` : (0, codegen_1._) `{type: ${schemaValue}}`,
 };
 function reportTypeError(it) {
     const cxt = getTypeErrorContext(it);
-    errors_1.reportError(cxt, typeError);
+    (0, errors_1.reportError)(cxt, typeError);
 }
 exports.reportTypeError = reportTypeError;
 function getTypeErrorContext(it) {
     const { gen, data, schema } = it;
-    const schemaCode = util_1.schemaRefOrVal(it, schema, "type");
+    const schemaCode = (0, util_1.schemaRefOrVal)(it, schema, "type");
     return {
         gen,
         keyword: "type",
@@ -1655,8 +1655,8 @@ var defaults = {};
 
 Object.defineProperty(defaults, "__esModule", { value: true });
 defaults.assignDefaults = void 0;
-const codegen_1$r = codegen;
-const util_1$o = util;
+const codegen_1$v = codegen;
+const util_1$s = util;
 function assignDefaults(it, ty) {
     const { properties, items } = it.schema;
     if (ty === "object" && properties) {
@@ -1673,18 +1673,18 @@ function assignDefault(it, prop, defaultValue) {
     const { gen, compositeRule, data, opts } = it;
     if (defaultValue === undefined)
         return;
-    const childData = codegen_1$r._ `${data}${codegen_1$r.getProperty(prop)}`;
+    const childData = (0, codegen_1$v._) `${data}${(0, codegen_1$v.getProperty)(prop)}`;
     if (compositeRule) {
-        util_1$o.checkStrictMode(it, `default is ignored for: ${childData}`);
+        (0, util_1$s.checkStrictMode)(it, `default is ignored for: ${childData}`);
         return;
     }
-    let condition = codegen_1$r._ `${childData} === undefined`;
+    let condition = (0, codegen_1$v._) `${childData} === undefined`;
     if (opts.useDefaults === "empty") {
-        condition = codegen_1$r._ `${condition} || ${childData} === null || ${childData} === ""`;
+        condition = (0, codegen_1$v._) `${condition} || ${childData} === null || ${childData} === ""`;
     }
     // `${childData} === undefined` +
     // (opts.useDefaults === "empty" ? ` || ${childData} === null || ${childData} === ""` : "")
-    gen.if(condition, codegen_1$r._ `${childData} = ${codegen_1$r.stringify(defaultValue)}`);
+    gen.if(condition, (0, codegen_1$v._) `${childData} = ${(0, codegen_1$v.stringify)(defaultValue)}`);
 }
 
 var keyword = {};
@@ -1693,19 +1693,20 @@ var code = {};
 
 Object.defineProperty(code, "__esModule", { value: true });
 code.validateUnion = code.validateArray = code.usePattern = code.callValidateCode = code.schemaProperties = code.allSchemaProperties = code.noPropertyInData = code.propertyInData = code.isOwnProperty = code.hasPropFunc = code.reportMissingProp = code.checkMissingProp = code.checkReportMissingProp = void 0;
-const codegen_1$q = codegen;
-const util_1$n = util;
-const names_1$5 = names$1;
+const codegen_1$u = codegen;
+const util_1$r = util;
+const names_1$8 = names$1;
+const util_2$1 = util;
 function checkReportMissingProp(cxt, prop) {
     const { gen, data, it } = cxt;
     gen.if(noPropertyInData(gen, data, prop, it.opts.ownProperties), () => {
-        cxt.setParams({ missingProperty: codegen_1$q._ `${prop}` }, true);
+        cxt.setParams({ missingProperty: (0, codegen_1$u._) `${prop}` }, true);
         cxt.error();
     });
 }
 code.checkReportMissingProp = checkReportMissingProp;
 function checkMissingProp({ gen, data, it: { opts } }, properties, missing) {
-    return codegen_1$q.or(...properties.map((prop) => codegen_1$q.and(noPropertyInData(gen, data, prop, opts.ownProperties), codegen_1$q._ `${missing} = ${prop}`)));
+    return (0, codegen_1$u.or)(...properties.map((prop) => (0, codegen_1$u.and)(noPropertyInData(gen, data, prop, opts.ownProperties), (0, codegen_1$u._) `${missing} = ${prop}`)));
 }
 code.checkMissingProp = checkMissingProp;
 function reportMissingProp(cxt, missing) {
@@ -1717,22 +1718,22 @@ function hasPropFunc(gen) {
     return gen.scopeValue("func", {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         ref: Object.prototype.hasOwnProperty,
-        code: codegen_1$q._ `Object.prototype.hasOwnProperty`,
+        code: (0, codegen_1$u._) `Object.prototype.hasOwnProperty`,
     });
 }
 code.hasPropFunc = hasPropFunc;
 function isOwnProperty(gen, data, property) {
-    return codegen_1$q._ `${hasPropFunc(gen)}.call(${data}, ${property})`;
+    return (0, codegen_1$u._) `${hasPropFunc(gen)}.call(${data}, ${property})`;
 }
 code.isOwnProperty = isOwnProperty;
 function propertyInData(gen, data, property, ownProperties) {
-    const cond = codegen_1$q._ `${data}${codegen_1$q.getProperty(property)} !== undefined`;
-    return ownProperties ? codegen_1$q._ `${cond} && ${isOwnProperty(gen, data, property)}` : cond;
+    const cond = (0, codegen_1$u._) `${data}${(0, codegen_1$u.getProperty)(property)} !== undefined`;
+    return ownProperties ? (0, codegen_1$u._) `${cond} && ${isOwnProperty(gen, data, property)}` : cond;
 }
 code.propertyInData = propertyInData;
 function noPropertyInData(gen, data, property, ownProperties) {
-    const cond = codegen_1$q._ `${data}${codegen_1$q.getProperty(property)} === undefined`;
-    return ownProperties ? codegen_1$q.or(cond, codegen_1$q.not(isOwnProperty(gen, data, property))) : cond;
+    const cond = (0, codegen_1$u._) `${data}${(0, codegen_1$u.getProperty)(property)} === undefined`;
+    return ownProperties ? (0, codegen_1$u.or)(cond, (0, codegen_1$u.not)(isOwnProperty(gen, data, property))) : cond;
 }
 code.noPropertyInData = noPropertyInData;
 function allSchemaProperties(schemaMap) {
@@ -1740,29 +1741,31 @@ function allSchemaProperties(schemaMap) {
 }
 code.allSchemaProperties = allSchemaProperties;
 function schemaProperties(it, schemaMap) {
-    return allSchemaProperties(schemaMap).filter((p) => !util_1$n.alwaysValidSchema(it, schemaMap[p]));
+    return allSchemaProperties(schemaMap).filter((p) => !(0, util_1$r.alwaysValidSchema)(it, schemaMap[p]));
 }
 code.schemaProperties = schemaProperties;
 function callValidateCode({ schemaCode, data, it: { gen, topSchemaRef, schemaPath, errorPath }, it }, func, context, passSchema) {
-    const dataAndSchema = passSchema ? codegen_1$q._ `${schemaCode}, ${data}, ${topSchemaRef}${schemaPath}` : data;
+    const dataAndSchema = passSchema ? (0, codegen_1$u._) `${schemaCode}, ${data}, ${topSchemaRef}${schemaPath}` : data;
     const valCxt = [
-        [names_1$5.default.instancePath, codegen_1$q.strConcat(names_1$5.default.instancePath, errorPath)],
-        [names_1$5.default.parentData, it.parentData],
-        [names_1$5.default.parentDataProperty, it.parentDataProperty],
-        [names_1$5.default.rootData, names_1$5.default.rootData],
+        [names_1$8.default.instancePath, (0, codegen_1$u.strConcat)(names_1$8.default.instancePath, errorPath)],
+        [names_1$8.default.parentData, it.parentData],
+        [names_1$8.default.parentDataProperty, it.parentDataProperty],
+        [names_1$8.default.rootData, names_1$8.default.rootData],
     ];
     if (it.opts.dynamicRef)
-        valCxt.push([names_1$5.default.dynamicAnchors, names_1$5.default.dynamicAnchors]);
-    const args = codegen_1$q._ `${dataAndSchema}, ${gen.object(...valCxt)}`;
-    return context !== codegen_1$q.nil ? codegen_1$q._ `${func}.call(${context}, ${args})` : codegen_1$q._ `${func}(${args})`;
+        valCxt.push([names_1$8.default.dynamicAnchors, names_1$8.default.dynamicAnchors]);
+    const args = (0, codegen_1$u._) `${dataAndSchema}, ${gen.object(...valCxt)}`;
+    return context !== codegen_1$u.nil ? (0, codegen_1$u._) `${func}.call(${context}, ${args})` : (0, codegen_1$u._) `${func}(${args})`;
 }
 code.callValidateCode = callValidateCode;
+const newRegExp = (0, codegen_1$u._) `new RegExp`;
 function usePattern({ gen, it: { opts } }, pattern) {
     const u = opts.unicodeRegExp ? "u" : "";
+    const { regExp } = opts.code;
     return gen.scopeValue("pattern", {
         key: pattern,
-        ref: new RegExp(pattern, u),
-        code: codegen_1$q._ `new RegExp(${pattern}, ${u})`,
+        ref: regExp(pattern, u),
+        code: (0, codegen_1$u._) `${regExp.code === "new RegExp" ? newRegExp : (0, util_2$1.useFunc)(gen, regExp)}(${pattern}, ${u})`,
     });
 }
 code.usePattern = usePattern;
@@ -1778,14 +1781,14 @@ function validateArray(cxt) {
     validateItems(() => gen.break());
     return valid;
     function validateItems(notValid) {
-        const len = gen.const("len", codegen_1$q._ `${data}.length`);
+        const len = gen.const("len", (0, codegen_1$u._) `${data}.length`);
         gen.forRange("i", 0, len, (i) => {
             cxt.subschema({
                 keyword,
                 dataProp: i,
-                dataPropType: util_1$n.Type.Num,
+                dataPropType: util_1$r.Type.Num,
             }, valid);
-            gen.if(codegen_1$q.not(valid), notValid);
+            gen.if((0, codegen_1$u.not)(valid), notValid);
         });
     }
 }
@@ -1795,7 +1798,7 @@ function validateUnion(cxt) {
     /* istanbul ignore if */
     if (!Array.isArray(schema))
         throw new Error("ajv implementation error");
-    const alwaysValid = schema.some((sch) => util_1$n.alwaysValidSchema(it, sch));
+    const alwaysValid = schema.some((sch) => (0, util_1$r.alwaysValidSchema)(it, sch));
     if (alwaysValid && !it.opts.unevaluated)
         return;
     const valid = gen.let("valid", false);
@@ -1806,12 +1809,12 @@ function validateUnion(cxt) {
             schemaProp: i,
             compositeRule: true,
         }, schValid);
-        gen.assign(valid, codegen_1$q._ `${valid} || ${schValid}`);
+        gen.assign(valid, (0, codegen_1$u._) `${valid} || ${schValid}`);
         const merged = cxt.mergeValidEvaluated(schCxt, schValid);
         // can short-circuit if `unevaluatedProperties/Items` not supported (opts.unevaluated !== true)
         // or if all properties and items were evaluated (it.props === true && it.items === true)
         if (!merged)
-            gen.if(codegen_1$q.not(valid));
+            gen.if((0, codegen_1$u.not)(valid));
     }));
     cxt.result(valid, () => cxt.reset(), () => cxt.error(true));
 }
@@ -1819,8 +1822,8 @@ code.validateUnion = validateUnion;
 
 Object.defineProperty(keyword, "__esModule", { value: true });
 keyword.validateKeywordUsage = keyword.validSchemaType = keyword.funcKeywordCode = keyword.macroKeywordCode = void 0;
-const codegen_1$p = codegen;
-const names_1$4 = names$1;
+const codegen_1$t = codegen;
+const names_1$7 = names$1;
 const code_1$9 = code;
 const errors_1$1 = errors;
 function macroKeywordCode(cxt, def) {
@@ -1832,7 +1835,7 @@ function macroKeywordCode(cxt, def) {
     const valid = gen.name("valid");
     cxt.subschema({
         schema: macroSchema,
-        schemaPath: codegen_1$p.nil,
+        schemaPath: codegen_1$t.nil,
         errSchemaPath: `${it.errSchemaPath}/${keyword}`,
         topSchemaRef: schemaRef,
         compositeRule: true,
@@ -1865,37 +1868,37 @@ function funcKeywordCode(cxt, def) {
     }
     function validateAsync() {
         const ruleErrs = gen.let("ruleErrs", null);
-        gen.try(() => assignValid(codegen_1$p._ `await `), (e) => gen.assign(valid, false).if(codegen_1$p._ `${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, codegen_1$p._ `${e}.errors`), () => gen.throw(e)));
+        gen.try(() => assignValid((0, codegen_1$t._) `await `), (e) => gen.assign(valid, false).if((0, codegen_1$t._) `${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, (0, codegen_1$t._) `${e}.errors`), () => gen.throw(e)));
         return ruleErrs;
     }
     function validateSync() {
-        const validateErrs = codegen_1$p._ `${validateRef}.errors`;
+        const validateErrs = (0, codegen_1$t._) `${validateRef}.errors`;
         gen.assign(validateErrs, null);
-        assignValid(codegen_1$p.nil);
+        assignValid(codegen_1$t.nil);
         return validateErrs;
     }
-    function assignValid(_await = def.async ? codegen_1$p._ `await ` : codegen_1$p.nil) {
-        const passCxt = it.opts.passContext ? names_1$4.default.this : names_1$4.default.self;
+    function assignValid(_await = def.async ? (0, codegen_1$t._) `await ` : codegen_1$t.nil) {
+        const passCxt = it.opts.passContext ? names_1$7.default.this : names_1$7.default.self;
         const passSchema = !(("compile" in def && !$data) || def.schema === false);
-        gen.assign(valid, codegen_1$p._ `${_await}${code_1$9.callValidateCode(cxt, validateRef, passCxt, passSchema)}`, def.modifying);
+        gen.assign(valid, (0, codegen_1$t._) `${_await}${(0, code_1$9.callValidateCode)(cxt, validateRef, passCxt, passSchema)}`, def.modifying);
     }
     function reportErrs(errors) {
         var _a;
-        gen.if(codegen_1$p.not((_a = def.valid) !== null && _a !== void 0 ? _a : valid), errors);
+        gen.if((0, codegen_1$t.not)((_a = def.valid) !== null && _a !== void 0 ? _a : valid), errors);
     }
 }
 keyword.funcKeywordCode = funcKeywordCode;
 function modifyData(cxt) {
     const { gen, data, it } = cxt;
-    gen.if(it.parentData, () => gen.assign(data, codegen_1$p._ `${it.parentData}[${it.parentDataProperty}]`));
+    gen.if(it.parentData, () => gen.assign(data, (0, codegen_1$t._) `${it.parentData}[${it.parentDataProperty}]`));
 }
 function addErrs(cxt, errs) {
     const { gen } = cxt;
-    gen.if(codegen_1$p._ `Array.isArray(${errs})`, () => {
+    gen.if((0, codegen_1$t._) `Array.isArray(${errs})`, () => {
         gen
-            .assign(names_1$4.default.vErrors, codegen_1$p._ `${names_1$4.default.vErrors} === null ? ${errs} : ${names_1$4.default.vErrors}.concat(${errs})`)
-            .assign(names_1$4.default.errors, codegen_1$p._ `${names_1$4.default.vErrors}.length`);
-        errors_1$1.extendErrors(cxt);
+            .assign(names_1$7.default.vErrors, (0, codegen_1$t._) `${names_1$7.default.vErrors} === null ? ${errs} : ${names_1$7.default.vErrors}.concat(${errs})`)
+            .assign(names_1$7.default.errors, (0, codegen_1$t._) `${names_1$7.default.vErrors}.length`);
+        (0, errors_1$1.extendErrors)(cxt);
     }, () => cxt.error());
 }
 function checkAsyncKeyword({ schemaEnv }, def) {
@@ -1905,7 +1908,7 @@ function checkAsyncKeyword({ schemaEnv }, def) {
 function useKeyword(gen, keyword, result) {
     if (result === undefined)
         throw new Error(`keyword "${keyword}" failed to compile`);
-    return gen.scopeValue("keyword", typeof result == "function" ? { ref: result } : { ref: result, code: codegen_1$p.stringify(result) });
+    return gen.scopeValue("keyword", typeof result == "function" ? { ref: result } : { ref: result, code: (0, codegen_1$t.stringify)(result) });
 }
 function validSchemaType(schema, schemaType, allowUndefined = false) {
     // TODO add tests
@@ -1944,8 +1947,8 @@ var subschema = {};
 
 Object.defineProperty(subschema, "__esModule", { value: true });
 subschema.extendSubschemaMode = subschema.extendSubschemaData = subschema.getSubschema = void 0;
-const codegen_1$o = codegen;
-const util_1$m = util;
+const codegen_1$s = codegen;
+const util_1$q = util;
 function getSubschema(it, { keyword, schemaProp, schema, schemaPath, errSchemaPath, topSchemaRef }) {
     if (keyword !== undefined && schema !== undefined) {
         throw new Error('both "keyword" and "schema" passed, only one allowed');
@@ -1955,13 +1958,13 @@ function getSubschema(it, { keyword, schemaProp, schema, schemaPath, errSchemaPa
         return schemaProp === undefined
             ? {
                 schema: sch,
-                schemaPath: codegen_1$o._ `${it.schemaPath}${codegen_1$o.getProperty(keyword)}`,
+                schemaPath: (0, codegen_1$s._) `${it.schemaPath}${(0, codegen_1$s.getProperty)(keyword)}`,
                 errSchemaPath: `${it.errSchemaPath}/${keyword}`,
             }
             : {
                 schema: sch[schemaProp],
-                schemaPath: codegen_1$o._ `${it.schemaPath}${codegen_1$o.getProperty(keyword)}${codegen_1$o.getProperty(schemaProp)}`,
-                errSchemaPath: `${it.errSchemaPath}/${keyword}/${util_1$m.escapeFragment(schemaProp)}`,
+                schemaPath: (0, codegen_1$s._) `${it.schemaPath}${(0, codegen_1$s.getProperty)(keyword)}${(0, codegen_1$s.getProperty)(schemaProp)}`,
+                errSchemaPath: `${it.errSchemaPath}/${keyword}/${(0, util_1$q.escapeFragment)(schemaProp)}`,
             };
     }
     if (schema !== undefined) {
@@ -1985,14 +1988,14 @@ function extendSubschemaData(subschema, it, { dataProp, dataPropType: dpType, da
     const { gen } = it;
     if (dataProp !== undefined) {
         const { errorPath, dataPathArr, opts } = it;
-        const nextData = gen.let("data", codegen_1$o._ `${it.data}${codegen_1$o.getProperty(dataProp)}`, true);
+        const nextData = gen.let("data", (0, codegen_1$s._) `${it.data}${(0, codegen_1$s.getProperty)(dataProp)}`, true);
         dataContextProps(nextData);
-        subschema.errorPath = codegen_1$o.str `${errorPath}${util_1$m.getErrorPath(dataProp, dpType, opts.jsPropertySyntax)}`;
-        subschema.parentDataProperty = codegen_1$o._ `${dataProp}`;
+        subschema.errorPath = (0, codegen_1$s.str) `${errorPath}${(0, util_1$q.getErrorPath)(dataProp, dpType, opts.jsPropertySyntax)}`;
+        subschema.parentDataProperty = (0, codegen_1$s._) `${dataProp}`;
         subschema.dataPathArr = [...dataPathArr, subschema.parentDataProperty];
     }
     if (data !== undefined) {
-        const nextData = data instanceof codegen_1$o.Name ? data : gen.let("data", data, true); // replaceable if used once?
+        const nextData = data instanceof codegen_1$s.Name ? data : gen.let("data", data, true); // replaceable if used once?
         dataContextProps(nextData);
         if (propertyName !== undefined)
             subschema.propertyName = propertyName;
@@ -3573,7 +3576,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 Object.defineProperty(resolve$1, "__esModule", { value: true });
 resolve$1.getSchemaRefs = resolve$1.resolveUrl = resolve$1.normalizeId = resolve$1._getFullPath = resolve$1.getFullPath = resolve$1.inlineRef = void 0;
-const util_1$l = util;
+const util_1$p = util;
 const equal$2 = fastDeepEqual;
 const traverse = jsonSchemaTraverse.exports;
 const URI$1 = uri_all.exports;
@@ -3634,7 +3637,7 @@ function countKeys(schema) {
         if (SIMPLE_INLINED.has(key))
             continue;
         if (typeof schema[key] == "object") {
-            util_1$l.eachItem(schema[key], (sch) => (count += countKeys(sch)));
+            (0, util_1$p.eachItem)(schema[key], (sch) => (count += countKeys(sch)));
         }
         if (count === Infinity)
             return Infinity;
@@ -3663,11 +3666,11 @@ function resolveUrl(baseId, id) {
 }
 resolve$1.resolveUrl = resolveUrl;
 const ANCHOR = /^[a-z_][-a-z0-9._]*$/i;
-function getSchemaRefs(schema) {
+function getSchemaRefs(schema, baseId) {
     if (typeof schema == "boolean")
         return {};
     const { schemaId } = this.opts;
-    const schId = normalizeId(schema[schemaId]);
+    const schId = normalizeId(schema[schemaId] || baseId);
     const baseIds = { "": schId };
     const pathPrefix = getFullPath(schId, false);
     const localRefs = {};
@@ -3732,10 +3735,10 @@ const dataType_2 = dataType;
 const defaults_1 = defaults;
 const keyword_1 = keyword;
 const subschema_1 = subschema;
-const codegen_1$n = codegen;
-const names_1$3 = names$1;
+const codegen_1$r = codegen;
+const names_1$6 = names$1;
 const resolve_1$2 = resolve$1;
-const util_1$k = util;
+const util_1$o = util;
 const errors_1 = errors;
 // schema compilation - generates validation function, subschemaCode (below) is used for subschemas
 function validateFunctionCode(it) {
@@ -3746,39 +3749,39 @@ function validateFunctionCode(it) {
             return;
         }
     }
-    validateFunction(it, () => boolSchema_1.topBoolOrEmptySchema(it));
+    validateFunction(it, () => (0, boolSchema_1.topBoolOrEmptySchema)(it));
 }
 validate.validateFunctionCode = validateFunctionCode;
 function validateFunction({ gen, validateName, schema, schemaEnv, opts }, body) {
     if (opts.code.es5) {
-        gen.func(validateName, codegen_1$n._ `${names_1$3.default.data}, ${names_1$3.default.valCxt}`, schemaEnv.$async, () => {
-            gen.code(codegen_1$n._ `"use strict"; ${funcSourceUrl(schema, opts)}`);
+        gen.func(validateName, (0, codegen_1$r._) `${names_1$6.default.data}, ${names_1$6.default.valCxt}`, schemaEnv.$async, () => {
+            gen.code((0, codegen_1$r._) `"use strict"; ${funcSourceUrl(schema, opts)}`);
             destructureValCxtES5(gen, opts);
             gen.code(body);
         });
     }
     else {
-        gen.func(validateName, codegen_1$n._ `${names_1$3.default.data}, ${destructureValCxt(opts)}`, schemaEnv.$async, () => gen.code(funcSourceUrl(schema, opts)).code(body));
+        gen.func(validateName, (0, codegen_1$r._) `${names_1$6.default.data}, ${destructureValCxt(opts)}`, schemaEnv.$async, () => gen.code(funcSourceUrl(schema, opts)).code(body));
     }
 }
 function destructureValCxt(opts) {
-    return codegen_1$n._ `{${names_1$3.default.instancePath}="", ${names_1$3.default.parentData}, ${names_1$3.default.parentDataProperty}, ${names_1$3.default.rootData}=${names_1$3.default.data}${opts.dynamicRef ? codegen_1$n._ `, ${names_1$3.default.dynamicAnchors}={}` : codegen_1$n.nil}}={}`;
+    return (0, codegen_1$r._) `{${names_1$6.default.instancePath}="", ${names_1$6.default.parentData}, ${names_1$6.default.parentDataProperty}, ${names_1$6.default.rootData}=${names_1$6.default.data}${opts.dynamicRef ? (0, codegen_1$r._) `, ${names_1$6.default.dynamicAnchors}={}` : codegen_1$r.nil}}={}`;
 }
 function destructureValCxtES5(gen, opts) {
-    gen.if(names_1$3.default.valCxt, () => {
-        gen.var(names_1$3.default.instancePath, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.instancePath}`);
-        gen.var(names_1$3.default.parentData, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.parentData}`);
-        gen.var(names_1$3.default.parentDataProperty, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.parentDataProperty}`);
-        gen.var(names_1$3.default.rootData, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.rootData}`);
+    gen.if(names_1$6.default.valCxt, () => {
+        gen.var(names_1$6.default.instancePath, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.instancePath}`);
+        gen.var(names_1$6.default.parentData, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.parentData}`);
+        gen.var(names_1$6.default.parentDataProperty, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.parentDataProperty}`);
+        gen.var(names_1$6.default.rootData, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.rootData}`);
         if (opts.dynamicRef)
-            gen.var(names_1$3.default.dynamicAnchors, codegen_1$n._ `${names_1$3.default.valCxt}.${names_1$3.default.dynamicAnchors}`);
+            gen.var(names_1$6.default.dynamicAnchors, (0, codegen_1$r._) `${names_1$6.default.valCxt}.${names_1$6.default.dynamicAnchors}`);
     }, () => {
-        gen.var(names_1$3.default.instancePath, codegen_1$n._ `""`);
-        gen.var(names_1$3.default.parentData, codegen_1$n._ `undefined`);
-        gen.var(names_1$3.default.parentDataProperty, codegen_1$n._ `undefined`);
-        gen.var(names_1$3.default.rootData, names_1$3.default.data);
+        gen.var(names_1$6.default.instancePath, (0, codegen_1$r._) `""`);
+        gen.var(names_1$6.default.parentData, (0, codegen_1$r._) `undefined`);
+        gen.var(names_1$6.default.parentDataProperty, (0, codegen_1$r._) `undefined`);
+        gen.var(names_1$6.default.rootData, names_1$6.default.data);
         if (opts.dynamicRef)
-            gen.var(names_1$3.default.dynamicAnchors, codegen_1$n._ `{}`);
+            gen.var(names_1$6.default.dynamicAnchors, (0, codegen_1$r._) `{}`);
     });
 }
 function topSchemaObjCode(it) {
@@ -3787,8 +3790,8 @@ function topSchemaObjCode(it) {
         if (opts.$comment && schema.$comment)
             commentKeyword(it);
         checkNoDefault(it);
-        gen.let(names_1$3.default.vErrors, null);
-        gen.let(names_1$3.default.errors, 0);
+        gen.let(names_1$6.default.vErrors, null);
+        gen.let(names_1$6.default.errors, 0);
         if (opts.unevaluated)
             resetEvaluated(it);
         typeAndKeywords(it);
@@ -3799,13 +3802,13 @@ function topSchemaObjCode(it) {
 function resetEvaluated(it) {
     // TODO maybe some hook to execute it in the end to check whether props/items are Name, as in assignEvaluated
     const { gen, validateName } = it;
-    it.evaluated = gen.const("evaluated", codegen_1$n._ `${validateName}.evaluated`);
-    gen.if(codegen_1$n._ `${it.evaluated}.dynamicProps`, () => gen.assign(codegen_1$n._ `${it.evaluated}.props`, codegen_1$n._ `undefined`));
-    gen.if(codegen_1$n._ `${it.evaluated}.dynamicItems`, () => gen.assign(codegen_1$n._ `${it.evaluated}.items`, codegen_1$n._ `undefined`));
+    it.evaluated = gen.const("evaluated", (0, codegen_1$r._) `${validateName}.evaluated`);
+    gen.if((0, codegen_1$r._) `${it.evaluated}.dynamicProps`, () => gen.assign((0, codegen_1$r._) `${it.evaluated}.props`, (0, codegen_1$r._) `undefined`));
+    gen.if((0, codegen_1$r._) `${it.evaluated}.dynamicItems`, () => gen.assign((0, codegen_1$r._) `${it.evaluated}.items`, (0, codegen_1$r._) `undefined`));
 }
 function funcSourceUrl(schema, opts) {
     const schId = typeof schema == "object" && schema[opts.schemaId];
-    return schId && (opts.code.source || opts.code.process) ? codegen_1$n._ `/*# sourceURL=${schId} */` : codegen_1$n.nil;
+    return schId && (opts.code.source || opts.code.process) ? (0, codegen_1$r._) `/*# sourceURL=${schId} */` : codegen_1$r.nil;
 }
 // schema compilation - this function is used recursively to generate code for sub-schemas
 function subschemaCode(it, valid) {
@@ -3816,7 +3819,7 @@ function subschemaCode(it, valid) {
             return;
         }
     }
-    boolSchema_1.boolOrEmptySchema(it, valid);
+    (0, boolSchema_1.boolOrEmptySchema)(it, valid);
 }
 function schemaCxtHasRules({ schema, self }) {
     if (typeof schema == "boolean")
@@ -3835,38 +3838,38 @@ function subSchemaObjCode(it, valid) {
         commentKeyword(it);
     updateContext(it);
     checkAsyncSchema(it);
-    const errsCount = gen.const("_errs", names_1$3.default.errors);
+    const errsCount = gen.const("_errs", names_1$6.default.errors);
     typeAndKeywords(it, errsCount);
     // TODO var
-    gen.var(valid, codegen_1$n._ `${errsCount} === ${names_1$3.default.errors}`);
+    gen.var(valid, (0, codegen_1$r._) `${errsCount} === ${names_1$6.default.errors}`);
 }
 function checkKeywords(it) {
-    util_1$k.checkUnknownRules(it);
+    (0, util_1$o.checkUnknownRules)(it);
     checkRefsAndKeywords(it);
 }
 function typeAndKeywords(it, errsCount) {
     if (it.opts.jtd)
         return schemaKeywords(it, [], false, errsCount);
-    const types = dataType_1$1.getSchemaTypes(it.schema);
-    const checkedTypes = dataType_1$1.coerceAndCheckDataType(it, types);
+    const types = (0, dataType_1$1.getSchemaTypes)(it.schema);
+    const checkedTypes = (0, dataType_1$1.coerceAndCheckDataType)(it, types);
     schemaKeywords(it, types, !checkedTypes, errsCount);
 }
 function checkRefsAndKeywords(it) {
     const { schema, errSchemaPath, opts, self } = it;
-    if (schema.$ref && opts.ignoreKeywordsWithRef && util_1$k.schemaHasRulesButRef(schema, self.RULES)) {
+    if (schema.$ref && opts.ignoreKeywordsWithRef && (0, util_1$o.schemaHasRulesButRef)(schema, self.RULES)) {
         self.logger.warn(`$ref: keywords ignored in schema at path "${errSchemaPath}"`);
     }
 }
 function checkNoDefault(it) {
     const { schema, opts } = it;
     if (schema.default !== undefined && opts.useDefaults && opts.strictSchema) {
-        util_1$k.checkStrictMode(it, "default is ignored in the schema root");
+        (0, util_1$o.checkStrictMode)(it, "default is ignored in the schema root");
     }
 }
 function updateContext(it) {
     const schId = it.schema[it.opts.schemaId];
     if (schId)
-        it.baseId = resolve_1$2.resolveUrl(it.baseId, schId);
+        it.baseId = (0, resolve_1$2.resolveUrl)(it.baseId, schId);
 }
 function checkAsyncSchema(it) {
     if (it.schema.$async && !it.schemaEnv.$async)
@@ -3875,37 +3878,37 @@ function checkAsyncSchema(it) {
 function commentKeyword({ gen, schemaEnv, schema, errSchemaPath, opts }) {
     const msg = schema.$comment;
     if (opts.$comment === true) {
-        gen.code(codegen_1$n._ `${names_1$3.default.self}.logger.log(${msg})`);
+        gen.code((0, codegen_1$r._) `${names_1$6.default.self}.logger.log(${msg})`);
     }
     else if (typeof opts.$comment == "function") {
-        const schemaPath = codegen_1$n.str `${errSchemaPath}/$comment`;
+        const schemaPath = (0, codegen_1$r.str) `${errSchemaPath}/$comment`;
         const rootName = gen.scopeValue("root", { ref: schemaEnv.root });
-        gen.code(codegen_1$n._ `${names_1$3.default.self}.opts.$comment(${msg}, ${schemaPath}, ${rootName}.schema)`);
+        gen.code((0, codegen_1$r._) `${names_1$6.default.self}.opts.$comment(${msg}, ${schemaPath}, ${rootName}.schema)`);
     }
 }
 function returnResults(it) {
     const { gen, schemaEnv, validateName, ValidationError, opts } = it;
     if (schemaEnv.$async) {
         // TODO assign unevaluated
-        gen.if(codegen_1$n._ `${names_1$3.default.errors} === 0`, () => gen.return(names_1$3.default.data), () => gen.throw(codegen_1$n._ `new ${ValidationError}(${names_1$3.default.vErrors})`));
+        gen.if((0, codegen_1$r._) `${names_1$6.default.errors} === 0`, () => gen.return(names_1$6.default.data), () => gen.throw((0, codegen_1$r._) `new ${ValidationError}(${names_1$6.default.vErrors})`));
     }
     else {
-        gen.assign(codegen_1$n._ `${validateName}.errors`, names_1$3.default.vErrors);
+        gen.assign((0, codegen_1$r._) `${validateName}.errors`, names_1$6.default.vErrors);
         if (opts.unevaluated)
             assignEvaluated(it);
-        gen.return(codegen_1$n._ `${names_1$3.default.errors} === 0`);
+        gen.return((0, codegen_1$r._) `${names_1$6.default.errors} === 0`);
     }
 }
 function assignEvaluated({ gen, evaluated, props, items }) {
-    if (props instanceof codegen_1$n.Name)
-        gen.assign(codegen_1$n._ `${evaluated}.props`, props);
-    if (items instanceof codegen_1$n.Name)
-        gen.assign(codegen_1$n._ `${evaluated}.items`, items);
+    if (props instanceof codegen_1$r.Name)
+        gen.assign((0, codegen_1$r._) `${evaluated}.props`, props);
+    if (items instanceof codegen_1$r.Name)
+        gen.assign((0, codegen_1$r._) `${evaluated}.items`, items);
 }
 function schemaKeywords(it, types, typeErrors, errsCount) {
     const { gen, schema, data, allErrors, opts, self } = it;
     const { RULES } = self;
-    if (schema.$ref && (opts.ignoreKeywordsWithRef || !util_1$k.schemaHasRulesButRef(schema, RULES))) {
+    if (schema.$ref && (opts.ignoreKeywordsWithRef || !(0, util_1$o.schemaHasRulesButRef)(schema, RULES))) {
         gen.block(() => keywordCode(it, "$ref", RULES.all.$ref.definition)); // TODO typecast
         return;
     }
@@ -3917,14 +3920,14 @@ function schemaKeywords(it, types, typeErrors, errsCount) {
         groupKeywords(RULES.post);
     });
     function groupKeywords(group) {
-        if (!applicability_1.shouldUseGroup(schema, group))
+        if (!(0, applicability_1.shouldUseGroup)(schema, group))
             return;
         if (group.type) {
-            gen.if(dataType_2.checkDataType(group.type, data, opts.strictNumbers));
+            gen.if((0, dataType_2.checkDataType)(group.type, data, opts.strictNumbers));
             iterateKeywords(it, group);
             if (types.length === 1 && types[0] === group.type && typeErrors) {
                 gen.else();
-                dataType_2.reportTypeError(it);
+                (0, dataType_2.reportTypeError)(it);
             }
             gen.endIf();
         }
@@ -3933,16 +3936,16 @@ function schemaKeywords(it, types, typeErrors, errsCount) {
         }
         // TODO make it "ok" call?
         if (!allErrors)
-            gen.if(codegen_1$n._ `${names_1$3.default.errors} === ${errsCount || 0}`);
+            gen.if((0, codegen_1$r._) `${names_1$6.default.errors} === ${errsCount || 0}`);
     }
 }
 function iterateKeywords(it, group) {
     const { gen, schema, opts: { useDefaults }, } = it;
     if (useDefaults)
-        defaults_1.assignDefaults(it, group.type);
+        (0, defaults_1.assignDefaults)(it, group.type);
     gen.block(() => {
         for (const rule of group.rules) {
-            if (applicability_1.shouldUseRule(schema, rule)) {
+            if ((0, applicability_1.shouldUseRule)(schema, rule)) {
                 keywordCode(it, rule.keyword, rule.definition, group.type);
             }
         }
@@ -3979,7 +3982,7 @@ function checkKeywordTypes(it, ts) {
     const rules = it.self.RULES.all;
     for (const keyword in rules) {
         const rule = rules[keyword];
-        if (typeof rule == "object" && applicability_1.shouldUseRule(it.schema, rule)) {
+        if (typeof rule == "object" && (0, applicability_1.shouldUseRule)(it.schema, rule)) {
             const { type } = rule.definition;
             if (type.length && !type.some((t) => hasApplicableType(ts, t))) {
                 strictTypesError(it, `missing type "${type.join(",")}" for keyword "${keyword}"`);
@@ -3996,18 +3999,18 @@ function includesType(ts, t) {
 function strictTypesError(it, msg) {
     const schemaPath = it.schemaEnv.baseId + it.errSchemaPath;
     msg += ` at "${schemaPath}" (strictTypes)`;
-    util_1$k.checkStrictMode(it, msg, it.opts.strictTypes);
+    (0, util_1$o.checkStrictMode)(it, msg, it.opts.strictTypes);
 }
 class KeywordCxt {
     constructor(it, def, keyword) {
-        keyword_1.validateKeywordUsage(it, def, keyword);
+        (0, keyword_1.validateKeywordUsage)(it, def, keyword);
         this.gen = it.gen;
         this.allErrors = it.allErrors;
         this.keyword = keyword;
         this.data = it.data;
         this.schema = it.schema[keyword];
         this.$data = def.$data && it.opts.$data && this.schema && this.schema.$data;
-        this.schemaValue = util_1$k.schemaRefOrVal(it, this.schema, keyword, this.$data);
+        this.schemaValue = (0, util_1$o.schemaRefOrVal)(it, this.schema, keyword, this.$data);
         this.schemaType = def.schemaType;
         this.parentSchema = it.schema;
         this.params = {};
@@ -4018,16 +4021,16 @@ class KeywordCxt {
         }
         else {
             this.schemaCode = this.schemaValue;
-            if (!keyword_1.validSchemaType(this.schema, def.schemaType, def.allowUndefined)) {
+            if (!(0, keyword_1.validSchemaType)(this.schema, def.schemaType, def.allowUndefined)) {
                 throw new Error(`${keyword} value must be ${JSON.stringify(def.schemaType)}`);
             }
         }
         if ("code" in def ? def.trackErrors : def.errors !== false) {
-            this.errsCount = it.gen.const("_errs", names_1$3.default.errors);
+            this.errsCount = it.gen.const("_errs", names_1$6.default.errors);
         }
     }
     result(condition, successAction, failAction) {
-        this.failResult(codegen_1$n.not(condition), successAction, failAction);
+        this.failResult((0, codegen_1$r.not)(condition), successAction, failAction);
     }
     failResult(condition, successAction, failAction) {
         this.gen.if(condition);
@@ -4049,7 +4052,7 @@ class KeywordCxt {
         }
     }
     pass(condition, failAction) {
-        this.failResult(codegen_1$n.not(condition), undefined, failAction);
+        this.failResult((0, codegen_1$r.not)(condition), undefined, failAction);
     }
     fail(condition) {
         if (condition === undefined) {
@@ -4069,7 +4072,7 @@ class KeywordCxt {
         if (!this.$data)
             return this.fail(condition);
         const { schemaCode } = this;
-        this.fail(codegen_1$n._ `${schemaCode} !== undefined && (${codegen_1$n.or(this.invalid$data(), condition)})`);
+        this.fail((0, codegen_1$r._) `${schemaCode} !== undefined && (${(0, codegen_1$r.or)(this.invalid$data(), condition)})`);
     }
     error(append, errorParams, errorPaths) {
         if (errorParams) {
@@ -4084,12 +4087,12 @@ class KeywordCxt {
         (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
     }
     $dataError() {
-        errors_1.reportError(this, this.def.$dataError || errors_1.keyword$DataError);
+        (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
     }
     reset() {
         if (this.errsCount === undefined)
             throw new Error('add "trackErrors" to keyword definition');
-        errors_1.resetErrorsCount(this.gen, this.errsCount);
+        (0, errors_1.resetErrorsCount)(this.gen, this.errsCount);
     }
     ok(cond) {
         if (!this.allErrors)
@@ -4101,52 +4104,52 @@ class KeywordCxt {
         else
             this.params = obj;
     }
-    block$data(valid, codeBlock, $dataValid = codegen_1$n.nil) {
+    block$data(valid, codeBlock, $dataValid = codegen_1$r.nil) {
         this.gen.block(() => {
             this.check$data(valid, $dataValid);
             codeBlock();
         });
     }
-    check$data(valid = codegen_1$n.nil, $dataValid = codegen_1$n.nil) {
+    check$data(valid = codegen_1$r.nil, $dataValid = codegen_1$r.nil) {
         if (!this.$data)
             return;
         const { gen, schemaCode, schemaType, def } = this;
-        gen.if(codegen_1$n.or(codegen_1$n._ `${schemaCode} === undefined`, $dataValid));
-        if (valid !== codegen_1$n.nil)
+        gen.if((0, codegen_1$r.or)((0, codegen_1$r._) `${schemaCode} === undefined`, $dataValid));
+        if (valid !== codegen_1$r.nil)
             gen.assign(valid, true);
         if (schemaType.length || def.validateSchema) {
             gen.elseIf(this.invalid$data());
             this.$dataError();
-            if (valid !== codegen_1$n.nil)
+            if (valid !== codegen_1$r.nil)
                 gen.assign(valid, false);
         }
         gen.else();
     }
     invalid$data() {
         const { gen, schemaCode, schemaType, def, it } = this;
-        return codegen_1$n.or(wrong$DataType(), invalid$DataSchema());
+        return (0, codegen_1$r.or)(wrong$DataType(), invalid$DataSchema());
         function wrong$DataType() {
             if (schemaType.length) {
                 /* istanbul ignore if */
-                if (!(schemaCode instanceof codegen_1$n.Name))
+                if (!(schemaCode instanceof codegen_1$r.Name))
                     throw new Error("ajv implementation error");
                 const st = Array.isArray(schemaType) ? schemaType : [schemaType];
-                return codegen_1$n._ `${dataType_2.checkDataTypes(st, schemaCode, it.opts.strictNumbers, dataType_2.DataType.Wrong)}`;
+                return (0, codegen_1$r._) `${(0, dataType_2.checkDataTypes)(st, schemaCode, it.opts.strictNumbers, dataType_2.DataType.Wrong)}`;
             }
-            return codegen_1$n.nil;
+            return codegen_1$r.nil;
         }
         function invalid$DataSchema() {
             if (def.validateSchema) {
                 const validateSchemaRef = gen.scopeValue("validate$data", { ref: def.validateSchema }); // TODO value.code for standalone
-                return codegen_1$n._ `!${validateSchemaRef}(${schemaCode})`;
+                return (0, codegen_1$r._) `!${validateSchemaRef}(${schemaCode})`;
             }
-            return codegen_1$n.nil;
+            return codegen_1$r.nil;
         }
     }
     subschema(appl, valid) {
-        const subschema = subschema_1.getSubschema(this.it, appl);
-        subschema_1.extendSubschemaData(subschema, this.it, appl);
-        subschema_1.extendSubschemaMode(subschema, appl);
+        const subschema = (0, subschema_1.getSubschema)(this.it, appl);
+        (0, subschema_1.extendSubschemaData)(subschema, this.it, appl);
+        (0, subschema_1.extendSubschemaMode)(subschema, appl);
         const nextContext = { ...this.it, ...subschema, items: undefined, props: undefined };
         subschemaCode(nextContext, valid);
         return nextContext;
@@ -4156,16 +4159,16 @@ class KeywordCxt {
         if (!it.opts.unevaluated)
             return;
         if (it.props !== true && schemaCxt.props !== undefined) {
-            it.props = util_1$k.mergeEvaluated.props(gen, schemaCxt.props, it.props, toName);
+            it.props = util_1$o.mergeEvaluated.props(gen, schemaCxt.props, it.props, toName);
         }
         if (it.items !== true && schemaCxt.items !== undefined) {
-            it.items = util_1$k.mergeEvaluated.items(gen, schemaCxt.items, it.items, toName);
+            it.items = util_1$o.mergeEvaluated.items(gen, schemaCxt.items, it.items, toName);
         }
     }
     mergeValidEvaluated(schemaCxt, valid) {
         const { it, gen } = this;
         if (it.opts.unevaluated && (it.props !== true || it.items !== true)) {
-            gen.if(valid, () => this.mergeEvaluated(schemaCxt, codegen_1$n.Name));
+            gen.if(valid, () => this.mergeEvaluated(schemaCxt, codegen_1$r.Name));
             return true;
         }
     }
@@ -4177,13 +4180,13 @@ function keywordCode(it, keyword, def, ruleType) {
         def.code(cxt, ruleType);
     }
     else if (cxt.$data && def.validate) {
-        keyword_1.funcKeywordCode(cxt, def);
+        (0, keyword_1.funcKeywordCode)(cxt, def);
     }
     else if ("macro" in def) {
-        keyword_1.macroKeywordCode(cxt, def);
+        (0, keyword_1.macroKeywordCode)(cxt, def);
     }
     else if (def.compile || def.validate) {
-        keyword_1.funcKeywordCode(cxt, def);
+        (0, keyword_1.funcKeywordCode)(cxt, def);
     }
 }
 const JSON_POINTER = /^\/(?:[^~]|~0|~1)*$/;
@@ -4192,12 +4195,12 @@ function getData($data, { dataLevel, dataNames, dataPathArr }) {
     let jsonPointer;
     let data;
     if ($data === "")
-        return names_1$3.default.rootData;
+        return names_1$6.default.rootData;
     if ($data[0] === "/") {
         if (!JSON_POINTER.test($data))
             throw new Error(`Invalid JSON-pointer: ${$data}`);
         jsonPointer = $data;
-        data = names_1$3.default.rootData;
+        data = names_1$6.default.rootData;
     }
     else {
         const matches = RELATIVE_JSON_POINTER.exec($data);
@@ -4220,8 +4223,8 @@ function getData($data, { dataLevel, dataNames, dataPathArr }) {
     const segments = jsonPointer.split("/");
     for (const segment of segments) {
         if (segment) {
-            data = codegen_1$n._ `${data}${codegen_1$n.getProperty(util_1$k.unescapeJsonPointer(segment))}`;
-            expr = codegen_1$n._ `${expr} && ${data}`;
+            data = (0, codegen_1$r._) `${data}${(0, codegen_1$r.getProperty)((0, util_1$o.unescapeJsonPointer)(segment))}`;
+            expr = (0, codegen_1$r._) `${expr} && ${data}`;
         }
     }
     return expr;
@@ -4250,8 +4253,8 @@ const resolve_1$1 = resolve$1;
 class MissingRefError extends Error {
     constructor(baseId, ref, msg) {
         super(msg || `can't resolve reference ${ref} from id ${baseId}`);
-        this.missingRef = resolve_1$1.resolveUrl(baseId, ref);
-        this.missingSchema = resolve_1$1.normalizeId(resolve_1$1.getFullPath(this.missingRef));
+        this.missingRef = (0, resolve_1$1.resolveUrl)(baseId, ref);
+        this.missingSchema = (0, resolve_1$1.normalizeId)((0, resolve_1$1.getFullPath)(this.missingRef));
     }
 }
 ref_error.default = MissingRefError;
@@ -4260,11 +4263,11 @@ var compile = {};
 
 Object.defineProperty(compile, "__esModule", { value: true });
 compile.resolveSchema = compile.getCompilingSchema = compile.resolveRef = compile.compileSchema = compile.SchemaEnv = void 0;
-const codegen_1$m = codegen;
+const codegen_1$q = codegen;
 const validation_error_1 = validation_error;
-const names_1$2 = names$1;
+const names_1$5 = names$1;
 const resolve_1 = resolve$1;
-const util_1$j = util;
+const util_1$n = util;
 const validate_1$1 = validate;
 const URI = uri_all.exports;
 class SchemaEnv {
@@ -4278,7 +4281,7 @@ class SchemaEnv {
         this.schema = env.schema;
         this.schemaId = env.schemaId;
         this.root = env.root || this;
-        this.baseId = (_a = env.baseId) !== null && _a !== void 0 ? _a : resolve_1.normalizeId(schema === null || schema === void 0 ? void 0 : schema[env.schemaId || "$id"]);
+        this.baseId = (_a = env.baseId) !== null && _a !== void 0 ? _a : (0, resolve_1.normalizeId)(schema === null || schema === void 0 ? void 0 : schema[env.schemaId || "$id"]);
         this.schemaPath = env.schemaPath;
         this.localRefs = env.localRefs;
         this.meta = env.meta;
@@ -4295,15 +4298,15 @@ function compileSchema(sch) {
     const _sch = getCompilingSchema.call(this, sch);
     if (_sch)
         return _sch;
-    const rootId = resolve_1.getFullPath(sch.root.baseId); // TODO if getFullPath removed 1 tests fails
+    const rootId = (0, resolve_1.getFullPath)(sch.root.baseId); // TODO if getFullPath removed 1 tests fails
     const { es5, lines } = this.opts.code;
     const { ownProperties } = this.opts;
-    const gen = new codegen_1$m.CodeGen(this.scope, { es5, lines, ownProperties });
+    const gen = new codegen_1$q.CodeGen(this.scope, { es5, lines, ownProperties });
     let _ValidationError;
     if (sch.$async) {
         _ValidationError = gen.scopeValue("Error", {
             ref: validation_error_1.default,
-            code: codegen_1$m._ `require("ajv/dist/runtime/validation_error").default`,
+            code: (0, codegen_1$q._) `require("ajv/dist/runtime/validation_error").default`,
         });
     }
     const validateName = gen.scopeName("validate");
@@ -4311,16 +4314,16 @@ function compileSchema(sch) {
     const schemaCxt = {
         gen,
         allErrors: this.opts.allErrors,
-        data: names_1$2.default.data,
-        parentData: names_1$2.default.parentData,
-        parentDataProperty: names_1$2.default.parentDataProperty,
-        dataNames: [names_1$2.default.data],
-        dataPathArr: [codegen_1$m.nil],
+        data: names_1$5.default.data,
+        parentData: names_1$5.default.parentData,
+        parentDataProperty: names_1$5.default.parentDataProperty,
+        dataNames: [names_1$5.default.data],
+        dataPathArr: [codegen_1$q.nil],
         dataLevel: 0,
         dataTypes: [],
         definedProperties: new Set(),
         topSchemaRef: gen.scopeValue("schema", this.opts.code.source === true
-            ? { ref: sch.schema, code: codegen_1$m.stringify(sch.schema) }
+            ? { ref: sch.schema, code: (0, codegen_1$q.stringify)(sch.schema) }
             : { ref: sch.schema }),
         validateName,
         ValidationError: _ValidationError,
@@ -4328,25 +4331,25 @@ function compileSchema(sch) {
         schemaEnv: sch,
         rootId,
         baseId: sch.baseId || rootId,
-        schemaPath: codegen_1$m.nil,
+        schemaPath: codegen_1$q.nil,
         errSchemaPath: sch.schemaPath || (this.opts.jtd ? "" : "#"),
-        errorPath: codegen_1$m._ `""`,
+        errorPath: (0, codegen_1$q._) `""`,
         opts: this.opts,
         self: this,
     };
     let sourceCode;
     try {
         this._compilations.add(sch);
-        validate_1$1.validateFunctionCode(schemaCxt);
+        (0, validate_1$1.validateFunctionCode)(schemaCxt);
         gen.optimize(this.opts.code.optimize);
         // gen.optimize(1)
         const validateCode = gen.toString();
-        sourceCode = `${gen.scopeRefs(names_1$2.default.scope)}return ${validateCode}`;
+        sourceCode = `${gen.scopeRefs(names_1$5.default.scope)}return ${validateCode}`;
         // console.log((codeSize += sourceCode.length), (nodeCount += gen.nodeCount))
         if (this.opts.code.process)
             sourceCode = this.opts.code.process(sourceCode, sch);
         // console.log("\n\n\n *** \n", sourceCode)
-        const makeValidate = new Function(`${names_1$2.default.self}`, `${names_1$2.default.scope}`, sourceCode);
+        const makeValidate = new Function(`${names_1$5.default.self}`, `${names_1$5.default.scope}`, sourceCode);
         const validate = makeValidate(this, this.scope.get());
         this.scope.value(validateName, { ref: validate });
         validate.errors = null;
@@ -4360,13 +4363,13 @@ function compileSchema(sch) {
         if (this.opts.unevaluated) {
             const { props, items } = schemaCxt;
             validate.evaluated = {
-                props: props instanceof codegen_1$m.Name ? undefined : props,
-                items: items instanceof codegen_1$m.Name ? undefined : items,
-                dynamicProps: props instanceof codegen_1$m.Name,
-                dynamicItems: items instanceof codegen_1$m.Name,
+                props: props instanceof codegen_1$q.Name ? undefined : props,
+                items: items instanceof codegen_1$q.Name ? undefined : items,
+                dynamicProps: props instanceof codegen_1$q.Name,
+                dynamicItems: items instanceof codegen_1$q.Name,
             };
             if (validate.source)
-                validate.source.evaluated = codegen_1$m.stringify(validate.evaluated);
+                validate.source.evaluated = (0, codegen_1$q.stringify)(validate.evaluated);
         }
         sch.validate = validate;
         return sch;
@@ -4386,7 +4389,7 @@ function compileSchema(sch) {
 compile.compileSchema = compileSchema;
 function resolveRef(root, baseId, ref) {
     var _a;
-    ref = resolve_1.resolveUrl(baseId, ref);
+    ref = (0, resolve_1.resolveUrl)(baseId, ref);
     const schOrFunc = root.refs[ref];
     if (schOrFunc)
         return schOrFunc;
@@ -4403,7 +4406,7 @@ function resolveRef(root, baseId, ref) {
 }
 compile.resolveRef = resolveRef;
 function inlineOrCompile(sch) {
-    if (resolve_1.inlineRef(sch.schema, this.opts.inlineRefs))
+    if ((0, resolve_1.inlineRef)(sch.schema, this.opts.inlineRefs))
         return sch.schema;
     return sch.validate ? sch : compileSchema.call(this, sch);
 }
@@ -4433,13 +4436,13 @@ function resolveSchema(root, // root object with properties schema, refs TODO be
 ref // reference to resolve
 ) {
     const p = URI.parse(ref);
-    const refPath = resolve_1._getFullPath(p);
-    let baseId = resolve_1.getFullPath(root.baseId);
+    const refPath = (0, resolve_1._getFullPath)(p);
+    let baseId = (0, resolve_1.getFullPath)(root.baseId);
     // TODO `Object.keys(root.schema).length > 0` should not be needed - but removing breaks 2 tests
     if (Object.keys(root.schema).length > 0 && refPath === baseId) {
         return getJsonPointer.call(this, p, root);
     }
-    const id = resolve_1.normalizeId(refPath);
+    const id = (0, resolve_1.normalizeId)(refPath);
     const schOrRef = this.refs[id] || this.schemas[id];
     if (typeof schOrRef == "string") {
         const sch = resolveSchema.call(this, root, schOrRef);
@@ -4451,12 +4454,12 @@ ref // reference to resolve
         return;
     if (!schOrRef.validate)
         compileSchema.call(this, schOrRef);
-    if (id === resolve_1.normalizeId(ref)) {
+    if (id === (0, resolve_1.normalizeId)(ref)) {
         const { schema } = schOrRef;
         const { schemaId } = this.opts;
         const schId = schema[schemaId];
         if (schId)
-            baseId = resolve_1.resolveUrl(baseId, schId);
+            baseId = (0, resolve_1.resolveUrl)(baseId, schId);
         return new SchemaEnv({ schema, schemaId, root, baseId });
     }
     return getJsonPointer.call(this, p, schOrRef);
@@ -4474,20 +4477,21 @@ function getJsonPointer(parsedRef, { baseId, schema, root }) {
     if (((_a = parsedRef.fragment) === null || _a === void 0 ? void 0 : _a[0]) !== "/")
         return;
     for (const part of parsedRef.fragment.slice(1).split("/")) {
-        if (typeof schema == "boolean")
+        if (typeof schema === "boolean")
             return;
-        schema = schema[util_1$j.unescapeFragment(part)];
-        if (schema === undefined)
+        const partSchema = schema[(0, util_1$n.unescapeFragment)(part)];
+        if (partSchema === undefined)
             return;
+        schema = partSchema;
         // TODO PREVENT_SCOPE_CHANGE could be defined in keyword def?
-        const schId = typeof schema == "object" && schema[this.opts.schemaId];
+        const schId = typeof schema === "object" && schema[this.opts.schemaId];
         if (!PREVENT_SCOPE_CHANGE.has(part) && schId) {
-            baseId = resolve_1.resolveUrl(baseId, schId);
+            baseId = (0, resolve_1.resolveUrl)(baseId, schId);
         }
     }
     let env;
-    if (typeof schema != "boolean" && schema.$ref && !util_1$j.schemaHasRulesButRef(schema, this.RULES)) {
-        const $ref = resolve_1.resolveUrl(baseId, schema.$ref);
+    if (typeof schema != "boolean" && schema.$ref && !(0, util_1$n.schemaHasRulesButRef)(schema, this.RULES)) {
+        const $ref = (0, resolve_1.resolveUrl)(baseId, schema.$ref);
         env = resolveSchema.call(this, root, $ref);
     }
     // even though resolution failed we need to return SchemaEnv to throw exception
@@ -4499,13 +4503,13 @@ function getJsonPointer(parsedRef, { baseId, schema, root }) {
     return undefined;
 }
 
-var $id$1 = "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#";
-var description$k = "Meta-schema for $data reference (JSON AnySchema extension proposal)";
-var type$j = "object";
+var $id$a = "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#";
+var description$l = "Meta-schema for $data reference (JSON AnySchema extension proposal)";
+var type$q = "object";
 var required$j = [
 	"$data"
 ];
-var properties$j = {
+var properties$q = {
 	$data: {
 		type: "string",
 		anyOf: [
@@ -4520,11 +4524,11 @@ var properties$j = {
 };
 var additionalProperties$i = false;
 var require$$9 = {
-	$id: $id$1,
-	description: description$k,
-	type: type$j,
+	$id: $id$a,
+	description: description$l,
+	type: type$q,
 	required: required$j,
-	properties: properties$j,
+	properties: properties$q,
 	additionalProperties: additionalProperties$i
 };
 
@@ -4549,6 +4553,8 @@ const resolve_1 = resolve$1;
 const dataType_1 = dataType;
 const util_1 = util;
 const $dataRefSchema = require$$9;
+const defaultRegExp = (str, flags) => new RegExp(str, flags);
+defaultRegExp.code = "new RegExp";
 const META_IGNORE_OPTIONS = ["removeAdditional", "useDefaults", "coerceTypes"];
 const EXT_SCOPE_NAMES = new Set([
     "validate",
@@ -4590,28 +4596,29 @@ const deprecatedOptions = {
 const MAX_EXPRESSION = 200;
 // eslint-disable-next-line complexity
 function requiredOptions(o) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z;
     const s = o.strict;
     const _optz = (_a = o.code) === null || _a === void 0 ? void 0 : _a.optimize;
     const optimize = _optz === true || _optz === undefined ? 1 : _optz || 0;
+    const regExp = (_c = (_b = o.code) === null || _b === void 0 ? void 0 : _b.regExp) !== null && _c !== void 0 ? _c : defaultRegExp;
     return {
-        strictSchema: (_c = (_b = o.strictSchema) !== null && _b !== void 0 ? _b : s) !== null && _c !== void 0 ? _c : true,
-        strictNumbers: (_e = (_d = o.strictNumbers) !== null && _d !== void 0 ? _d : s) !== null && _e !== void 0 ? _e : true,
-        strictTypes: (_g = (_f = o.strictTypes) !== null && _f !== void 0 ? _f : s) !== null && _g !== void 0 ? _g : "log",
-        strictTuples: (_j = (_h = o.strictTuples) !== null && _h !== void 0 ? _h : s) !== null && _j !== void 0 ? _j : "log",
-        strictRequired: (_l = (_k = o.strictRequired) !== null && _k !== void 0 ? _k : s) !== null && _l !== void 0 ? _l : false,
-        code: o.code ? { ...o.code, optimize } : { optimize },
-        loopRequired: (_m = o.loopRequired) !== null && _m !== void 0 ? _m : MAX_EXPRESSION,
-        loopEnum: (_o = o.loopEnum) !== null && _o !== void 0 ? _o : MAX_EXPRESSION,
-        meta: (_p = o.meta) !== null && _p !== void 0 ? _p : true,
-        messages: (_q = o.messages) !== null && _q !== void 0 ? _q : true,
-        inlineRefs: (_r = o.inlineRefs) !== null && _r !== void 0 ? _r : true,
-        schemaId: (_s = o.schemaId) !== null && _s !== void 0 ? _s : "$id",
-        addUsedSchema: (_t = o.addUsedSchema) !== null && _t !== void 0 ? _t : true,
-        validateSchema: (_u = o.validateSchema) !== null && _u !== void 0 ? _u : true,
-        validateFormats: (_v = o.validateFormats) !== null && _v !== void 0 ? _v : true,
-        unicodeRegExp: (_w = o.unicodeRegExp) !== null && _w !== void 0 ? _w : true,
-        int32range: (_x = o.int32range) !== null && _x !== void 0 ? _x : true,
+        strictSchema: (_e = (_d = o.strictSchema) !== null && _d !== void 0 ? _d : s) !== null && _e !== void 0 ? _e : true,
+        strictNumbers: (_g = (_f = o.strictNumbers) !== null && _f !== void 0 ? _f : s) !== null && _g !== void 0 ? _g : true,
+        strictTypes: (_j = (_h = o.strictTypes) !== null && _h !== void 0 ? _h : s) !== null && _j !== void 0 ? _j : "log",
+        strictTuples: (_l = (_k = o.strictTuples) !== null && _k !== void 0 ? _k : s) !== null && _l !== void 0 ? _l : "log",
+        strictRequired: (_o = (_m = o.strictRequired) !== null && _m !== void 0 ? _m : s) !== null && _o !== void 0 ? _o : false,
+        code: o.code ? { ...o.code, optimize, regExp } : { optimize, regExp },
+        loopRequired: (_p = o.loopRequired) !== null && _p !== void 0 ? _p : MAX_EXPRESSION,
+        loopEnum: (_q = o.loopEnum) !== null && _q !== void 0 ? _q : MAX_EXPRESSION,
+        meta: (_r = o.meta) !== null && _r !== void 0 ? _r : true,
+        messages: (_s = o.messages) !== null && _s !== void 0 ? _s : true,
+        inlineRefs: (_t = o.inlineRefs) !== null && _t !== void 0 ? _t : true,
+        schemaId: (_u = o.schemaId) !== null && _u !== void 0 ? _u : "$id",
+        addUsedSchema: (_v = o.addUsedSchema) !== null && _v !== void 0 ? _v : true,
+        validateSchema: (_w = o.validateSchema) !== null && _w !== void 0 ? _w : true,
+        validateFormats: (_x = o.validateFormats) !== null && _x !== void 0 ? _x : true,
+        unicodeRegExp: (_y = o.unicodeRegExp) !== null && _y !== void 0 ? _y : true,
+        int32range: (_z = o.int32range) !== null && _z !== void 0 ? _z : true,
     };
 }
 class Ajv {
@@ -4628,7 +4635,7 @@ class Ajv {
         this.logger = getLogger(opts.logger);
         const formatOpt = opts.validateFormats;
         opts.validateFormats = false;
-        this.RULES = rules_1.getRules();
+        this.RULES = (0, rules_1.getRules)();
         checkOptions.call(this, removedOptions, opts, "NOT SUPPORTED");
         checkOptions.call(this, deprecatedOptions, opts, "DEPRECATED", "warn");
         this._metaOpts = getMetaSchemaOptions.call(this);
@@ -4753,7 +4760,7 @@ class Ajv {
                 throw new Error(`schema ${schemaId} must be string`);
             }
         }
-        key = resolve_1.normalizeId(key || id);
+        key = (0, resolve_1.normalizeId)(key || id);
         this._checkUnique(key);
         this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true);
         return this;
@@ -4836,7 +4843,7 @@ class Ajv {
                 this._cache.delete(cacheKey);
                 let id = schemaKeyRef[this.opts.schemaId];
                 if (id) {
-                    id = resolve_1.normalizeId(id);
+                    id = (0, resolve_1.normalizeId)(id);
                     delete this.schemas[id];
                     delete this.refs[id];
                 }
@@ -4874,16 +4881,16 @@ class Ajv {
         }
         checkKeyword.call(this, keyword, def);
         if (!def) {
-            util_1.eachItem(keyword, (kwd) => addRule.call(this, kwd));
+            (0, util_1.eachItem)(keyword, (kwd) => addRule.call(this, kwd));
             return this;
         }
         keywordMetaschema.call(this, def);
         const definition = {
             ...def,
-            type: dataType_1.getJSONTypes(def.type),
-            schemaType: dataType_1.getJSONTypes(def.schemaType),
+            type: (0, dataType_1.getJSONTypes)(def.type),
+            schemaType: (0, dataType_1.getJSONTypes)(def.schemaType),
         };
-        util_1.eachItem(keyword, definition.type.length === 0
+        (0, util_1.eachItem)(keyword, definition.type.length === 0
             ? (k) => addRule.call(this, k, definition)
             : (k) => definition.type.forEach((t) => addRule.call(this, k, definition, t)));
         return this;
@@ -4970,8 +4977,8 @@ class Ajv {
         let sch = this._cache.get(schema);
         if (sch !== undefined)
             return sch;
-        const localRefs = resolve_1.getSchemaRefs.call(this, schema);
-        baseId = resolve_1.normalizeId(id || baseId);
+        baseId = (0, resolve_1.normalizeId)(id || baseId);
+        const localRefs = resolve_1.getSchemaRefs.call(this, schema, baseId);
         sch = new compile_1.SchemaEnv({ schema, schemaId, meta, baseId, localRefs });
         this._cache.set(sch.schema, sch);
         if (addSchema && !baseId.startsWith("#")) {
@@ -5021,7 +5028,7 @@ function checkOptions(checkOpts, options, msg, log = "error") {
     }
 }
 function getSchEnv(keyRef) {
-    keyRef = resolve_1.normalizeId(keyRef); // TODO tests fail without this line
+    keyRef = (0, resolve_1.normalizeId)(keyRef); // TODO tests fail without this line
     return this.schemas[keyRef] || this.refs[keyRef];
 }
 function addInitialSchemas() {
@@ -5073,7 +5080,7 @@ function getLogger(logger) {
 const KEYWORD_NAME = /^[a-z_$][a-z0-9_$:-]*$/i;
 function checkKeyword(keyword, def) {
     const { RULES } = this;
-    util_1.eachItem(keyword, (kwd) => {
+    (0, util_1.eachItem)(keyword, (kwd) => {
         if (RULES.keywords[kwd])
             throw new Error(`Keyword ${kwd} is already defined`);
         if (!KEYWORD_NAME.test(kwd))
@@ -5103,8 +5110,8 @@ function addRule(keyword, definition, dataType) {
         keyword,
         definition: {
             ...definition,
-            type: dataType_1.getJSONTypes(definition.type),
-            schemaType: dataType_1.getJSONTypes(definition.schemaType),
+            type: (0, dataType_1.getJSONTypes)(definition.type),
+            schemaType: (0, dataType_1.getJSONTypes)(definition.schemaType),
         },
     };
     if (definition.before)
@@ -5139,22 +5146,22 @@ function schemaOrData(schema) {
     return { anyOf: [schema, $dataRef] };
 }
 
-}(core$2));
+}(core$3));
 
-var draft7 = {};
+var draft2020 = {};
 
-var core$1 = {};
+var core$2 = {};
 
 var id = {};
 
 Object.defineProperty(id, "__esModule", { value: true });
-const def$s = {
+const def$B = {
     keyword: "id",
     code() {
         throw new Error('NOT SUPPORTED: keyword "id", use "$id" for schema ID');
     },
 };
-id.default = def$s;
+id.default = def$B;
 
 var ref = {};
 
@@ -5162,11 +5169,11 @@ Object.defineProperty(ref, "__esModule", { value: true });
 ref.callRef = ref.getValidate = void 0;
 const ref_error_1 = ref_error;
 const code_1$8 = code;
-const codegen_1$l = codegen;
-const names_1$1 = names$1;
-const compile_1 = compile;
-const util_1$i = util;
-const def$r = {
+const codegen_1$p = codegen;
+const names_1$4 = names$1;
+const compile_1$1 = compile;
+const util_1$m = util;
+const def$A = {
     keyword: "$ref",
     schemaType: "string",
     code(cxt) {
@@ -5175,29 +5182,29 @@ const def$r = {
         const { root } = env;
         if (($ref === "#" || $ref === "#/") && baseId === root.baseId)
             return callRootRef();
-        const schOrEnv = compile_1.resolveRef.call(self, root, baseId, $ref);
+        const schOrEnv = compile_1$1.resolveRef.call(self, root, baseId, $ref);
         if (schOrEnv === undefined)
             throw new ref_error_1.default(baseId, $ref);
-        if (schOrEnv instanceof compile_1.SchemaEnv)
+        if (schOrEnv instanceof compile_1$1.SchemaEnv)
             return callValidate(schOrEnv);
         return inlineRefSchema(schOrEnv);
         function callRootRef() {
             if (env === root)
                 return callRef(cxt, validateName, env, env.$async);
             const rootName = gen.scopeValue("root", { ref: root });
-            return callRef(cxt, codegen_1$l._ `${rootName}.validate`, root, root.$async);
+            return callRef(cxt, (0, codegen_1$p._) `${rootName}.validate`, root, root.$async);
         }
         function callValidate(sch) {
             const v = getValidate(cxt, sch);
             callRef(cxt, v, sch, sch.$async);
         }
         function inlineRefSchema(sch) {
-            const schName = gen.scopeValue("schema", opts.code.source === true ? { ref: sch, code: codegen_1$l.stringify(sch) } : { ref: sch });
+            const schName = gen.scopeValue("schema", opts.code.source === true ? { ref: sch, code: (0, codegen_1$p.stringify)(sch) } : { ref: sch });
             const valid = gen.name("valid");
             const schCxt = cxt.subschema({
                 schema: sch,
                 dataTypes: [],
-                schemaPath: codegen_1$l.nil,
+                schemaPath: codegen_1$p.nil,
                 topSchemaRef: schName,
                 errSchemaPath: $ref,
             }, valid);
@@ -5210,13 +5217,13 @@ function getValidate(cxt, sch) {
     const { gen } = cxt;
     return sch.validate
         ? gen.scopeValue("validate", { ref: sch.validate })
-        : codegen_1$l._ `${gen.scopeValue("wrapper", { ref: sch })}.validate`;
+        : (0, codegen_1$p._) `${gen.scopeValue("wrapper", { ref: sch })}.validate`;
 }
 ref.getValidate = getValidate;
 function callRef(cxt, v, sch, $async) {
     const { gen, it } = cxt;
     const { allErrors, schemaEnv: env, opts } = it;
-    const passCxt = opts.passContext ? names_1$1.default.this : codegen_1$l.nil;
+    const passCxt = opts.passContext ? names_1$4.default.this : codegen_1$p.nil;
     if ($async)
         callAsyncRef();
     else
@@ -5226,12 +5233,12 @@ function callRef(cxt, v, sch, $async) {
             throw new Error("async schema referenced by sync schema");
         const valid = gen.let("valid");
         gen.try(() => {
-            gen.code(codegen_1$l._ `await ${code_1$8.callValidateCode(cxt, v, passCxt)}`);
+            gen.code((0, codegen_1$p._) `await ${(0, code_1$8.callValidateCode)(cxt, v, passCxt)}`);
             addEvaluatedFrom(v); // TODO will not work with async, it has to be returned with the result
             if (!allErrors)
                 gen.assign(valid, true);
         }, (e) => {
-            gen.if(codegen_1$l._ `!(${e} instanceof ${it.ValidationError})`, () => gen.throw(e));
+            gen.if((0, codegen_1$p._) `!(${e} instanceof ${it.ValidationError})`, () => gen.throw(e));
             addErrorsFrom(e);
             if (!allErrors)
                 gen.assign(valid, false);
@@ -5239,12 +5246,12 @@ function callRef(cxt, v, sch, $async) {
         cxt.ok(valid);
     }
     function callSyncRef() {
-        cxt.result(code_1$8.callValidateCode(cxt, v, passCxt), () => addEvaluatedFrom(v), () => addErrorsFrom(v));
+        cxt.result((0, code_1$8.callValidateCode)(cxt, v, passCxt), () => addEvaluatedFrom(v), () => addErrorsFrom(v));
     }
     function addErrorsFrom(source) {
-        const errs = codegen_1$l._ `${source}.errors`;
-        gen.assign(names_1$1.default.vErrors, codegen_1$l._ `${names_1$1.default.vErrors} === null ? ${errs} : ${names_1$1.default.vErrors}.concat(${errs})`); // TODO tagged
-        gen.assign(names_1$1.default.errors, codegen_1$l._ `${names_1$1.default.vErrors}.length`);
+        const errs = (0, codegen_1$p._) `${source}.errors`;
+        gen.assign(names_1$4.default.vErrors, (0, codegen_1$p._) `${names_1$4.default.vErrors} === null ? ${errs} : ${names_1$4.default.vErrors}.concat(${errs})`); // TODO tagged
+        gen.assign(names_1$4.default.errors, (0, codegen_1$p._) `${names_1$4.default.vErrors}.length`);
     }
     function addEvaluatedFrom(source) {
         var _a;
@@ -5255,34 +5262,34 @@ function callRef(cxt, v, sch, $async) {
         if (it.props !== true) {
             if (schEvaluated && !schEvaluated.dynamicProps) {
                 if (schEvaluated.props !== undefined) {
-                    it.props = util_1$i.mergeEvaluated.props(gen, schEvaluated.props, it.props);
+                    it.props = util_1$m.mergeEvaluated.props(gen, schEvaluated.props, it.props);
                 }
             }
             else {
-                const props = gen.var("props", codegen_1$l._ `${source}.evaluated.props`);
-                it.props = util_1$i.mergeEvaluated.props(gen, props, it.props, codegen_1$l.Name);
+                const props = gen.var("props", (0, codegen_1$p._) `${source}.evaluated.props`);
+                it.props = util_1$m.mergeEvaluated.props(gen, props, it.props, codegen_1$p.Name);
             }
         }
         if (it.items !== true) {
             if (schEvaluated && !schEvaluated.dynamicItems) {
                 if (schEvaluated.items !== undefined) {
-                    it.items = util_1$i.mergeEvaluated.items(gen, schEvaluated.items, it.items);
+                    it.items = util_1$m.mergeEvaluated.items(gen, schEvaluated.items, it.items);
                 }
             }
             else {
-                const items = gen.var("items", codegen_1$l._ `${source}.evaluated.items`);
-                it.items = util_1$i.mergeEvaluated.items(gen, items, it.items, codegen_1$l.Name);
+                const items = gen.var("items", (0, codegen_1$p._) `${source}.evaluated.items`);
+                it.items = util_1$m.mergeEvaluated.items(gen, items, it.items, codegen_1$p.Name);
             }
         }
     }
 }
 ref.callRef = callRef;
-ref.default = def$r;
+ref.default = def$A;
 
-Object.defineProperty(core$1, "__esModule", { value: true });
+Object.defineProperty(core$2, "__esModule", { value: true });
 const id_1 = id;
-const ref_1 = ref;
-const core = [
+const ref_1$2 = ref;
+const core$1 = [
     "$schema",
     "$id",
     "$defs",
@@ -5290,66 +5297,66 @@ const core = [
     { keyword: "$comment" },
     "definitions",
     id_1.default,
-    ref_1.default,
+    ref_1$2.default,
 ];
-core$1.default = core;
+core$2.default = core$1;
 
-var validation$1 = {};
+var validation$2 = {};
 
 var limitNumber = {};
 
 Object.defineProperty(limitNumber, "__esModule", { value: true });
-const codegen_1$k = codegen;
-const ops = codegen_1$k.operators;
+const codegen_1$o = codegen;
+const ops = codegen_1$o.operators;
 const KWDs = {
     maximum: { okStr: "<=", ok: ops.LTE, fail: ops.GT },
     minimum: { okStr: ">=", ok: ops.GTE, fail: ops.LT },
     exclusiveMaximum: { okStr: "<", ok: ops.LT, fail: ops.GTE },
     exclusiveMinimum: { okStr: ">", ok: ops.GT, fail: ops.LTE },
 };
-const error$i = {
-    message: ({ keyword, schemaCode }) => codegen_1$k.str `must be ${KWDs[keyword].okStr} ${schemaCode}`,
-    params: ({ keyword, schemaCode }) => codegen_1$k._ `{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`,
+const error$k = {
+    message: ({ keyword, schemaCode }) => (0, codegen_1$o.str) `must be ${KWDs[keyword].okStr} ${schemaCode}`,
+    params: ({ keyword, schemaCode }) => (0, codegen_1$o._) `{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`,
 };
-const def$q = {
+const def$z = {
     keyword: Object.keys(KWDs),
     type: "number",
     schemaType: "number",
     $data: true,
-    error: error$i,
+    error: error$k,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        cxt.fail$data(codegen_1$k._ `${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
+        cxt.fail$data((0, codegen_1$o._) `${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
     },
 };
-limitNumber.default = def$q;
+limitNumber.default = def$z;
 
 var multipleOf = {};
 
 Object.defineProperty(multipleOf, "__esModule", { value: true });
-const codegen_1$j = codegen;
-const error$h = {
-    message: ({ schemaCode }) => codegen_1$j.str `must be multiple of ${schemaCode}`,
-    params: ({ schemaCode }) => codegen_1$j._ `{multipleOf: ${schemaCode}}`,
+const codegen_1$n = codegen;
+const error$j = {
+    message: ({ schemaCode }) => (0, codegen_1$n.str) `must be multiple of ${schemaCode}`,
+    params: ({ schemaCode }) => (0, codegen_1$n._) `{multipleOf: ${schemaCode}}`,
 };
-const def$p = {
+const def$y = {
     keyword: "multipleOf",
     type: "number",
     schemaType: "number",
     $data: true,
-    error: error$h,
+    error: error$j,
     code(cxt) {
         const { gen, data, schemaCode, it } = cxt;
         // const bdt = bad$DataType(schemaCode, <string>def.schemaType, $data)
         const prec = it.opts.multipleOfPrecision;
         const res = gen.let("res");
         const invalid = prec
-            ? codegen_1$j._ `Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}`
-            : codegen_1$j._ `${res} !== parseInt(${res})`;
-        cxt.fail$data(codegen_1$j._ `(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`);
+            ? (0, codegen_1$n._) `Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}`
+            : (0, codegen_1$n._) `${res} !== parseInt(${res})`;
+        cxt.fail$data((0, codegen_1$n._) `(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`);
     },
 };
-multipleOf.default = def$p;
+multipleOf.default = def$y;
 
 var limitLength = {};
 
@@ -5379,97 +5386,97 @@ ucs2length$1.default = ucs2length;
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default';
 
 Object.defineProperty(limitLength, "__esModule", { value: true });
-const codegen_1$i = codegen;
-const util_1$h = util;
+const codegen_1$m = codegen;
+const util_1$l = util;
 const ucs2length_1 = ucs2length$1;
-const error$g = {
+const error$i = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxLength" ? "more" : "fewer";
-        return codegen_1$i.str `must NOT have ${comp} than ${schemaCode} characters`;
+        return (0, codegen_1$m.str) `must NOT have ${comp} than ${schemaCode} characters`;
     },
-    params: ({ schemaCode }) => codegen_1$i._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$m._) `{limit: ${schemaCode}}`,
 };
-const def$o = {
+const def$x = {
     keyword: ["maxLength", "minLength"],
     type: "string",
     schemaType: "number",
     $data: true,
-    error: error$g,
+    error: error$i,
     code(cxt) {
         const { keyword, data, schemaCode, it } = cxt;
-        const op = keyword === "maxLength" ? codegen_1$i.operators.GT : codegen_1$i.operators.LT;
-        const len = it.opts.unicode === false ? codegen_1$i._ `${data}.length` : codegen_1$i._ `${util_1$h.useFunc(cxt.gen, ucs2length_1.default)}(${data})`;
-        cxt.fail$data(codegen_1$i._ `${len} ${op} ${schemaCode}`);
+        const op = keyword === "maxLength" ? codegen_1$m.operators.GT : codegen_1$m.operators.LT;
+        const len = it.opts.unicode === false ? (0, codegen_1$m._) `${data}.length` : (0, codegen_1$m._) `${(0, util_1$l.useFunc)(cxt.gen, ucs2length_1.default)}(${data})`;
+        cxt.fail$data((0, codegen_1$m._) `${len} ${op} ${schemaCode}`);
     },
 };
-limitLength.default = def$o;
+limitLength.default = def$x;
 
 var pattern = {};
 
 Object.defineProperty(pattern, "__esModule", { value: true });
 const code_1$7 = code;
-const codegen_1$h = codegen;
-const error$f = {
-    message: ({ schemaCode }) => codegen_1$h.str `must match pattern "${schemaCode}"`,
-    params: ({ schemaCode }) => codegen_1$h._ `{pattern: ${schemaCode}}`,
+const codegen_1$l = codegen;
+const error$h = {
+    message: ({ schemaCode }) => (0, codegen_1$l.str) `must match pattern "${schemaCode}"`,
+    params: ({ schemaCode }) => (0, codegen_1$l._) `{pattern: ${schemaCode}}`,
 };
-const def$n = {
+const def$w = {
     keyword: "pattern",
     type: "string",
     schemaType: "string",
     $data: true,
-    error: error$f,
+    error: error$h,
     code(cxt) {
         const { data, $data, schema, schemaCode, it } = cxt;
         // TODO regexp should be wrapped in try/catchs
         const u = it.opts.unicodeRegExp ? "u" : "";
-        const regExp = $data ? codegen_1$h._ `(new RegExp(${schemaCode}, ${u}))` : code_1$7.usePattern(cxt, schema);
-        cxt.fail$data(codegen_1$h._ `!${regExp}.test(${data})`);
+        const regExp = $data ? (0, codegen_1$l._) `(new RegExp(${schemaCode}, ${u}))` : (0, code_1$7.usePattern)(cxt, schema);
+        cxt.fail$data((0, codegen_1$l._) `!${regExp}.test(${data})`);
     },
 };
-pattern.default = def$n;
+pattern.default = def$w;
 
 var limitProperties = {};
 
 Object.defineProperty(limitProperties, "__esModule", { value: true });
-const codegen_1$g = codegen;
-const error$e = {
+const codegen_1$k = codegen;
+const error$g = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxProperties" ? "more" : "fewer";
-        return codegen_1$g.str `must NOT have ${comp} than ${schemaCode} items`;
+        return (0, codegen_1$k.str) `must NOT have ${comp} than ${schemaCode} items`;
     },
-    params: ({ schemaCode }) => codegen_1$g._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$k._) `{limit: ${schemaCode}}`,
 };
-const def$m = {
+const def$v = {
     keyword: ["maxProperties", "minProperties"],
     type: "object",
     schemaType: "number",
     $data: true,
-    error: error$e,
+    error: error$g,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        const op = keyword === "maxProperties" ? codegen_1$g.operators.GT : codegen_1$g.operators.LT;
-        cxt.fail$data(codegen_1$g._ `Object.keys(${data}).length ${op} ${schemaCode}`);
+        const op = keyword === "maxProperties" ? codegen_1$k.operators.GT : codegen_1$k.operators.LT;
+        cxt.fail$data((0, codegen_1$k._) `Object.keys(${data}).length ${op} ${schemaCode}`);
     },
 };
-limitProperties.default = def$m;
+limitProperties.default = def$v;
 
 var required$i = {};
 
 Object.defineProperty(required$i, "__esModule", { value: true });
 const code_1$6 = code;
-const codegen_1$f = codegen;
-const util_1$g = util;
-const error$d = {
-    message: ({ params: { missingProperty } }) => codegen_1$f.str `must have required property '${missingProperty}'`,
-    params: ({ params: { missingProperty } }) => codegen_1$f._ `{missingProperty: ${missingProperty}}`,
+const codegen_1$j = codegen;
+const util_1$k = util;
+const error$f = {
+    message: ({ params: { missingProperty } }) => (0, codegen_1$j.str) `must have required property '${missingProperty}'`,
+    params: ({ params: { missingProperty } }) => (0, codegen_1$j._) `{missingProperty: ${missingProperty}}`,
 };
-const def$l = {
+const def$u = {
     keyword: "required",
     type: "object",
     schemaType: "array",
     $data: true,
-    error: error$d,
+    error: error$f,
     code(cxt) {
         const { gen, schema, schemaCode, data, $data, it } = cxt;
         const { opts } = it;
@@ -5487,17 +5494,17 @@ const def$l = {
                 if ((props === null || props === void 0 ? void 0 : props[requiredKey]) === undefined && !definedProperties.has(requiredKey)) {
                     const schemaPath = it.schemaEnv.baseId + it.errSchemaPath;
                     const msg = `required property "${requiredKey}" is not defined at "${schemaPath}" (strictRequired)`;
-                    util_1$g.checkStrictMode(it, msg, it.opts.strictRequired);
+                    (0, util_1$k.checkStrictMode)(it, msg, it.opts.strictRequired);
                 }
             }
         }
         function allErrorsMode() {
             if (useLoop || $data) {
-                cxt.block$data(codegen_1$f.nil, loopAllRequired);
+                cxt.block$data(codegen_1$j.nil, loopAllRequired);
             }
             else {
                 for (const prop of schema) {
-                    code_1$6.checkReportMissingProp(cxt, prop);
+                    (0, code_1$6.checkReportMissingProp)(cxt, prop);
                 }
             }
         }
@@ -5509,55 +5516,55 @@ const def$l = {
                 cxt.ok(valid);
             }
             else {
-                gen.if(code_1$6.checkMissingProp(cxt, schema, missing));
-                code_1$6.reportMissingProp(cxt, missing);
+                gen.if((0, code_1$6.checkMissingProp)(cxt, schema, missing));
+                (0, code_1$6.reportMissingProp)(cxt, missing);
                 gen.else();
             }
         }
         function loopAllRequired() {
             gen.forOf("prop", schemaCode, (prop) => {
                 cxt.setParams({ missingProperty: prop });
-                gen.if(code_1$6.noPropertyInData(gen, data, prop, opts.ownProperties), () => cxt.error());
+                gen.if((0, code_1$6.noPropertyInData)(gen, data, prop, opts.ownProperties), () => cxt.error());
             });
         }
         function loopUntilMissing(missing, valid) {
             cxt.setParams({ missingProperty: missing });
             gen.forOf(missing, schemaCode, () => {
-                gen.assign(valid, code_1$6.propertyInData(gen, data, missing, opts.ownProperties));
-                gen.if(codegen_1$f.not(valid), () => {
+                gen.assign(valid, (0, code_1$6.propertyInData)(gen, data, missing, opts.ownProperties));
+                gen.if((0, codegen_1$j.not)(valid), () => {
                     cxt.error();
                     gen.break();
                 });
-            }, codegen_1$f.nil);
+            }, codegen_1$j.nil);
         }
     },
 };
-required$i.default = def$l;
+required$i.default = def$u;
 
 var limitItems = {};
 
 Object.defineProperty(limitItems, "__esModule", { value: true });
-const codegen_1$e = codegen;
-const error$c = {
+const codegen_1$i = codegen;
+const error$e = {
     message({ keyword, schemaCode }) {
         const comp = keyword === "maxItems" ? "more" : "fewer";
-        return codegen_1$e.str `must NOT have ${comp} than ${schemaCode} items`;
+        return (0, codegen_1$i.str) `must NOT have ${comp} than ${schemaCode} items`;
     },
-    params: ({ schemaCode }) => codegen_1$e._ `{limit: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$i._) `{limit: ${schemaCode}}`,
 };
-const def$k = {
+const def$t = {
     keyword: ["maxItems", "minItems"],
     type: "array",
     schemaType: "number",
     $data: true,
-    error: error$c,
+    error: error$e,
     code(cxt) {
         const { keyword, data, schemaCode } = cxt;
-        const op = keyword === "maxItems" ? codegen_1$e.operators.GT : codegen_1$e.operators.LT;
-        cxt.fail$data(codegen_1$e._ `${data}.length ${op} ${schemaCode}`);
+        const op = keyword === "maxItems" ? codegen_1$i.operators.GT : codegen_1$i.operators.LT;
+        cxt.fail$data((0, codegen_1$i._) `${data}.length ${op} ${schemaCode}`);
     },
 };
-limitItems.default = def$k;
+limitItems.default = def$t;
 
 var uniqueItems = {};
 
@@ -5571,114 +5578,114 @@ equal$1.default = equal;
 
 Object.defineProperty(uniqueItems, "__esModule", { value: true });
 const dataType_1 = dataType;
-const codegen_1$d = codegen;
-const util_1$f = util;
+const codegen_1$h = codegen;
+const util_1$j = util;
 const equal_1$2 = equal$1;
-const error$b = {
-    message: ({ params: { i, j } }) => codegen_1$d.str `must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
-    params: ({ params: { i, j } }) => codegen_1$d._ `{i: ${i}, j: ${j}}`,
+const error$d = {
+    message: ({ params: { i, j } }) => (0, codegen_1$h.str) `must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
+    params: ({ params: { i, j } }) => (0, codegen_1$h._) `{i: ${i}, j: ${j}}`,
 };
-const def$j = {
+const def$s = {
     keyword: "uniqueItems",
     type: "array",
     schemaType: "boolean",
     $data: true,
-    error: error$b,
+    error: error$d,
     code(cxt) {
         const { gen, data, $data, schema, parentSchema, schemaCode, it } = cxt;
         if (!$data && !schema)
             return;
         const valid = gen.let("valid");
-        const itemTypes = parentSchema.items ? dataType_1.getSchemaTypes(parentSchema.items) : [];
-        cxt.block$data(valid, validateUniqueItems, codegen_1$d._ `${schemaCode} === false`);
+        const itemTypes = parentSchema.items ? (0, dataType_1.getSchemaTypes)(parentSchema.items) : [];
+        cxt.block$data(valid, validateUniqueItems, (0, codegen_1$h._) `${schemaCode} === false`);
         cxt.ok(valid);
         function validateUniqueItems() {
-            const i = gen.let("i", codegen_1$d._ `${data}.length`);
+            const i = gen.let("i", (0, codegen_1$h._) `${data}.length`);
             const j = gen.let("j");
             cxt.setParams({ i, j });
             gen.assign(valid, true);
-            gen.if(codegen_1$d._ `${i} > 1`, () => (canOptimize() ? loopN : loopN2)(i, j));
+            gen.if((0, codegen_1$h._) `${i} > 1`, () => (canOptimize() ? loopN : loopN2)(i, j));
         }
         function canOptimize() {
             return itemTypes.length > 0 && !itemTypes.some((t) => t === "object" || t === "array");
         }
         function loopN(i, j) {
             const item = gen.name("item");
-            const wrongType = dataType_1.checkDataTypes(itemTypes, item, it.opts.strictNumbers, dataType_1.DataType.Wrong);
-            const indices = gen.const("indices", codegen_1$d._ `{}`);
-            gen.for(codegen_1$d._ `;${i}--;`, () => {
-                gen.let(item, codegen_1$d._ `${data}[${i}]`);
-                gen.if(wrongType, codegen_1$d._ `continue`);
+            const wrongType = (0, dataType_1.checkDataTypes)(itemTypes, item, it.opts.strictNumbers, dataType_1.DataType.Wrong);
+            const indices = gen.const("indices", (0, codegen_1$h._) `{}`);
+            gen.for((0, codegen_1$h._) `;${i}--;`, () => {
+                gen.let(item, (0, codegen_1$h._) `${data}[${i}]`);
+                gen.if(wrongType, (0, codegen_1$h._) `continue`);
                 if (itemTypes.length > 1)
-                    gen.if(codegen_1$d._ `typeof ${item} == "string"`, codegen_1$d._ `${item} += "_"`);
+                    gen.if((0, codegen_1$h._) `typeof ${item} == "string"`, (0, codegen_1$h._) `${item} += "_"`);
                 gen
-                    .if(codegen_1$d._ `typeof ${indices}[${item}] == "number"`, () => {
-                    gen.assign(j, codegen_1$d._ `${indices}[${item}]`);
+                    .if((0, codegen_1$h._) `typeof ${indices}[${item}] == "number"`, () => {
+                    gen.assign(j, (0, codegen_1$h._) `${indices}[${item}]`);
                     cxt.error();
                     gen.assign(valid, false).break();
                 })
-                    .code(codegen_1$d._ `${indices}[${item}] = ${i}`);
+                    .code((0, codegen_1$h._) `${indices}[${item}] = ${i}`);
             });
         }
         function loopN2(i, j) {
-            const eql = util_1$f.useFunc(gen, equal_1$2.default);
+            const eql = (0, util_1$j.useFunc)(gen, equal_1$2.default);
             const outer = gen.name("outer");
-            gen.label(outer).for(codegen_1$d._ `;${i}--;`, () => gen.for(codegen_1$d._ `${j} = ${i}; ${j}--;`, () => gen.if(codegen_1$d._ `${eql}(${data}[${i}], ${data}[${j}])`, () => {
+            gen.label(outer).for((0, codegen_1$h._) `;${i}--;`, () => gen.for((0, codegen_1$h._) `${j} = ${i}; ${j}--;`, () => gen.if((0, codegen_1$h._) `${eql}(${data}[${i}], ${data}[${j}])`, () => {
                 cxt.error();
                 gen.assign(valid, false).break(outer);
             })));
         }
     },
 };
-uniqueItems.default = def$j;
+uniqueItems.default = def$s;
 
 var _const = {};
 
 Object.defineProperty(_const, "__esModule", { value: true });
-const codegen_1$c = codegen;
-const util_1$e = util;
+const codegen_1$g = codegen;
+const util_1$i = util;
 const equal_1$1 = equal$1;
-const error$a = {
+const error$c = {
     message: "must be equal to constant",
-    params: ({ schemaCode }) => codegen_1$c._ `{allowedValue: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$g._) `{allowedValue: ${schemaCode}}`,
 };
-const def$i = {
+const def$r = {
     keyword: "const",
     $data: true,
-    error: error$a,
+    error: error$c,
     code(cxt) {
         const { gen, data, $data, schemaCode, schema } = cxt;
         if ($data || (schema && typeof schema == "object")) {
-            cxt.fail$data(codegen_1$c._ `!${util_1$e.useFunc(gen, equal_1$1.default)}(${data}, ${schemaCode})`);
+            cxt.fail$data((0, codegen_1$g._) `!${(0, util_1$i.useFunc)(gen, equal_1$1.default)}(${data}, ${schemaCode})`);
         }
         else {
-            cxt.fail(codegen_1$c._ `${schema} !== ${data}`);
+            cxt.fail((0, codegen_1$g._) `${schema} !== ${data}`);
         }
     },
 };
-_const.default = def$i;
+_const.default = def$r;
 
 var _enum = {};
 
 Object.defineProperty(_enum, "__esModule", { value: true });
-const codegen_1$b = codegen;
-const util_1$d = util;
+const codegen_1$f = codegen;
+const util_1$h = util;
 const equal_1 = equal$1;
-const error$9 = {
+const error$b = {
     message: "must be equal to one of the allowed values",
-    params: ({ schemaCode }) => codegen_1$b._ `{allowedValues: ${schemaCode}}`,
+    params: ({ schemaCode }) => (0, codegen_1$f._) `{allowedValues: ${schemaCode}}`,
 };
-const def$h = {
+const def$q = {
     keyword: "enum",
     schemaType: "array",
     $data: true,
-    error: error$9,
+    error: error$b,
     code(cxt) {
         const { gen, data, $data, schema, schemaCode, it } = cxt;
         if (!$data && schema.length === 0)
             throw new Error("enum must have non-empty array");
         const useLoop = schema.length >= it.opts.loopEnum;
-        const eql = util_1$d.useFunc(gen, equal_1.default);
+        const eql = (0, util_1$h.useFunc)(gen, equal_1.default);
         let valid;
         if (useLoop || $data) {
             valid = gen.let("valid");
@@ -5689,24 +5696,24 @@ const def$h = {
             if (!Array.isArray(schema))
                 throw new Error("ajv implementation error");
             const vSchema = gen.const("vSchema", schemaCode);
-            valid = codegen_1$b.or(...schema.map((_x, i) => equalCode(vSchema, i)));
+            valid = (0, codegen_1$f.or)(...schema.map((_x, i) => equalCode(vSchema, i)));
         }
         cxt.pass(valid);
         function loopEnum() {
             gen.assign(valid, false);
-            gen.forOf("v", schemaCode, (v) => gen.if(codegen_1$b._ `${eql}(${data}, ${v})`, () => gen.assign(valid, true).break()));
+            gen.forOf("v", schemaCode, (v) => gen.if((0, codegen_1$f._) `${eql}(${data}, ${v})`, () => gen.assign(valid, true).break()));
         }
         function equalCode(vSchema, i) {
             const sch = schema[i];
             return typeof sch === "object" && sch !== null
-                ? codegen_1$b._ `${eql}(${data}, ${vSchema}[${i}])`
-                : codegen_1$b._ `${data} === ${sch}`;
+                ? (0, codegen_1$f._) `${eql}(${data}, ${vSchema}[${i}])`
+                : (0, codegen_1$f._) `${data} === ${sch}`;
         }
     },
 };
-_enum.default = def$h;
+_enum.default = def$q;
 
-Object.defineProperty(validation$1, "__esModule", { value: true });
+Object.defineProperty(validation$2, "__esModule", { value: true });
 const limitNumber_1 = limitNumber;
 const multipleOf_1 = multipleOf;
 const limitLength_1 = limitLength;
@@ -5717,7 +5724,7 @@ const limitItems_1 = limitItems;
 const uniqueItems_1 = uniqueItems;
 const const_1 = _const;
 const enum_1 = _enum;
-const validation = [
+const validation$1 = [
     // number
     limitNumber_1.default,
     multipleOf_1.default,
@@ -5736,31 +5743,31 @@ const validation = [
     const_1.default,
     enum_1.default,
 ];
-validation$1.default = validation;
+validation$2.default = validation$1;
 
-var applicator = {};
+var applicator$1 = {};
 
 var additionalItems = {};
 
 Object.defineProperty(additionalItems, "__esModule", { value: true });
 additionalItems.validateAdditionalItems = void 0;
-const codegen_1$a = codegen;
-const util_1$c = util;
-const error$8 = {
-    message: ({ params: { len } }) => codegen_1$a.str `must NOT have more than ${len} items`,
-    params: ({ params: { len } }) => codegen_1$a._ `{limit: ${len}}`,
+const codegen_1$e = codegen;
+const util_1$g = util;
+const error$a = {
+    message: ({ params: { len } }) => (0, codegen_1$e.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$e._) `{limit: ${len}}`,
 };
-const def$g = {
+const def$p = {
     keyword: "additionalItems",
     type: "array",
     schemaType: ["boolean", "object"],
     before: "uniqueItems",
-    error: error$8,
+    error: error$a,
     code(cxt) {
         const { parentSchema, it } = cxt;
         const { items } = parentSchema;
         if (!Array.isArray(items)) {
-            util_1$c.checkStrictMode(it, '"additionalItems" is ignored when "items" is not an array of schemas');
+            (0, util_1$g.checkStrictMode)(it, '"additionalItems" is ignored when "items" is not an array of schemas');
             return;
         }
         validateAdditionalItems(cxt, items);
@@ -5769,26 +5776,26 @@ const def$g = {
 function validateAdditionalItems(cxt, items) {
     const { gen, schema, data, keyword, it } = cxt;
     it.items = true;
-    const len = gen.const("len", codegen_1$a._ `${data}.length`);
+    const len = gen.const("len", (0, codegen_1$e._) `${data}.length`);
     if (schema === false) {
         cxt.setParams({ len: items.length });
-        cxt.pass(codegen_1$a._ `${len} <= ${items.length}`);
+        cxt.pass((0, codegen_1$e._) `${len} <= ${items.length}`);
     }
-    else if (typeof schema == "object" && !util_1$c.alwaysValidSchema(it, schema)) {
-        const valid = gen.var("valid", codegen_1$a._ `${len} <= ${items.length}`); // TODO var
-        gen.if(codegen_1$a.not(valid), () => validateItems(valid));
+    else if (typeof schema == "object" && !(0, util_1$g.alwaysValidSchema)(it, schema)) {
+        const valid = gen.var("valid", (0, codegen_1$e._) `${len} <= ${items.length}`); // TODO var
+        gen.if((0, codegen_1$e.not)(valid), () => validateItems(valid));
         cxt.ok(valid);
     }
     function validateItems(valid) {
         gen.forRange("i", items.length, len, (i) => {
-            cxt.subschema({ keyword, dataProp: i, dataPropType: util_1$c.Type.Num }, valid);
+            cxt.subschema({ keyword, dataProp: i, dataPropType: util_1$g.Type.Num }, valid);
             if (!it.allErrors)
-                gen.if(codegen_1$a.not(valid), () => gen.break());
+                gen.if((0, codegen_1$e.not)(valid), () => gen.break());
         });
     }
 }
 additionalItems.validateAdditionalItems = validateAdditionalItems;
-additionalItems.default = def$g;
+additionalItems.default = def$p;
 
 var prefixItems = {};
 
@@ -5796,10 +5803,10 @@ var items = {};
 
 Object.defineProperty(items, "__esModule", { value: true });
 items.validateTuple = void 0;
-const codegen_1$9 = codegen;
-const util_1$b = util;
+const codegen_1$d = codegen;
+const util_1$f = util;
 const code_1$5 = code;
-const def$f = {
+const def$o = {
     keyword: "items",
     type: "array",
     schemaType: ["object", "array", "boolean"],
@@ -5809,23 +5816,23 @@ const def$f = {
         if (Array.isArray(schema))
             return validateTuple(cxt, "additionalItems", schema);
         it.items = true;
-        if (util_1$b.alwaysValidSchema(it, schema))
+        if ((0, util_1$f.alwaysValidSchema)(it, schema))
             return;
-        cxt.ok(code_1$5.validateArray(cxt));
+        cxt.ok((0, code_1$5.validateArray)(cxt));
     },
 };
 function validateTuple(cxt, extraItems, schArr = cxt.schema) {
     const { gen, parentSchema, data, keyword, it } = cxt;
     checkStrictTuple(parentSchema);
     if (it.opts.unevaluated && schArr.length && it.items !== true) {
-        it.items = util_1$b.mergeEvaluated.items(gen, schArr.length, it.items);
+        it.items = util_1$f.mergeEvaluated.items(gen, schArr.length, it.items);
     }
     const valid = gen.name("valid");
-    const len = gen.const("len", codegen_1$9._ `${data}.length`);
+    const len = gen.const("len", (0, codegen_1$d._) `${data}.length`);
     schArr.forEach((sch, i) => {
-        if (util_1$b.alwaysValidSchema(it, sch))
+        if ((0, util_1$f.alwaysValidSchema)(it, sch))
             return;
-        gen.if(codegen_1$9._ `${len} > ${i}`, () => cxt.subschema({
+        gen.if((0, codegen_1$d._) `${len} > ${i}`, () => cxt.subschema({
             keyword,
             schemaProp: i,
             dataProp: i,
@@ -5838,73 +5845,73 @@ function validateTuple(cxt, extraItems, schArr = cxt.schema) {
         const fullTuple = l === sch.minItems && (l === sch.maxItems || sch[extraItems] === false);
         if (opts.strictTuples && !fullTuple) {
             const msg = `"${keyword}" is ${l}-tuple, but minItems or maxItems/${extraItems} are not specified or different at path "${errSchemaPath}"`;
-            util_1$b.checkStrictMode(it, msg, opts.strictTuples);
+            (0, util_1$f.checkStrictMode)(it, msg, opts.strictTuples);
         }
     }
 }
 items.validateTuple = validateTuple;
-items.default = def$f;
+items.default = def$o;
 
 Object.defineProperty(prefixItems, "__esModule", { value: true });
 const items_1$1 = items;
-const def$e = {
+const def$n = {
     keyword: "prefixItems",
     type: "array",
     schemaType: ["array"],
     before: "uniqueItems",
-    code: (cxt) => items_1$1.validateTuple(cxt, "items"),
+    code: (cxt) => (0, items_1$1.validateTuple)(cxt, "items"),
 };
-prefixItems.default = def$e;
+prefixItems.default = def$n;
 
 var items2020 = {};
 
 Object.defineProperty(items2020, "__esModule", { value: true });
-const codegen_1$8 = codegen;
-const util_1$a = util;
+const codegen_1$c = codegen;
+const util_1$e = util;
 const code_1$4 = code;
 const additionalItems_1$1 = additionalItems;
-const error$7 = {
-    message: ({ params: { len } }) => codegen_1$8.str `must NOT have more than ${len} items`,
-    params: ({ params: { len } }) => codegen_1$8._ `{limit: ${len}}`,
+const error$9 = {
+    message: ({ params: { len } }) => (0, codegen_1$c.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$c._) `{limit: ${len}}`,
 };
-const def$d = {
+const def$m = {
     keyword: "items",
     type: "array",
     schemaType: ["object", "boolean"],
     before: "uniqueItems",
-    error: error$7,
+    error: error$9,
     code(cxt) {
         const { schema, parentSchema, it } = cxt;
         const { prefixItems } = parentSchema;
         it.items = true;
-        if (util_1$a.alwaysValidSchema(it, schema))
+        if ((0, util_1$e.alwaysValidSchema)(it, schema))
             return;
         if (prefixItems)
-            additionalItems_1$1.validateAdditionalItems(cxt, prefixItems);
+            (0, additionalItems_1$1.validateAdditionalItems)(cxt, prefixItems);
         else
-            cxt.ok(code_1$4.validateArray(cxt));
+            cxt.ok((0, code_1$4.validateArray)(cxt));
     },
 };
-items2020.default = def$d;
+items2020.default = def$m;
 
 var contains = {};
 
 Object.defineProperty(contains, "__esModule", { value: true });
-const codegen_1$7 = codegen;
-const util_1$9 = util;
-const error$6 = {
+const codegen_1$b = codegen;
+const util_1$d = util;
+const error$8 = {
     message: ({ params: { min, max } }) => max === undefined
-        ? codegen_1$7.str `must contain at least ${min} valid item(s)`
-        : codegen_1$7.str `must contain at least ${min} and no more than ${max} valid item(s)`,
-    params: ({ params: { min, max } }) => max === undefined ? codegen_1$7._ `{minContains: ${min}}` : codegen_1$7._ `{minContains: ${min}, maxContains: ${max}}`,
+        ? (0, codegen_1$b.str) `must contain at least ${min} valid item(s)`
+        : (0, codegen_1$b.str) `must contain at least ${min} and no more than ${max} valid item(s)`,
+    params: ({ params: { min, max } }) => max === undefined ? (0, codegen_1$b._) `{minContains: ${min}}` : (0, codegen_1$b._) `{minContains: ${min}, maxContains: ${max}}`,
 };
-const def$c = {
+const def$l = {
     keyword: "contains",
     type: "array",
     schemaType: ["object", "boolean"],
     before: "uniqueItems",
     trackErrors: true,
-    error: error$6,
+    error: error$8,
     code(cxt) {
         const { gen, schema, parentSchema, data, it } = cxt;
         let min;
@@ -5917,21 +5924,21 @@ const def$c = {
         else {
             min = 1;
         }
-        const len = gen.const("len", codegen_1$7._ `${data}.length`);
+        const len = gen.const("len", (0, codegen_1$b._) `${data}.length`);
         cxt.setParams({ min, max });
         if (max === undefined && min === 0) {
-            util_1$9.checkStrictMode(it, `"minContains" == 0 without "maxContains": "contains" keyword ignored`);
+            (0, util_1$d.checkStrictMode)(it, `"minContains" == 0 without "maxContains": "contains" keyword ignored`);
             return;
         }
         if (max !== undefined && min > max) {
-            util_1$9.checkStrictMode(it, `"minContains" > "maxContains" is always invalid`);
+            (0, util_1$d.checkStrictMode)(it, `"minContains" > "maxContains" is always invalid`);
             cxt.fail();
             return;
         }
-        if (util_1$9.alwaysValidSchema(it, schema)) {
-            let cond = codegen_1$7._ `${len} >= ${min}`;
+        if ((0, util_1$d.alwaysValidSchema)(it, schema)) {
+            let cond = (0, codegen_1$b._) `${len} >= ${min}`;
             if (max !== undefined)
-                cond = codegen_1$7._ `${cond} && ${len} <= ${max}`;
+                cond = (0, codegen_1$b._) `${cond} && ${len} <= ${max}`;
             cxt.pass(cond);
             return;
         }
@@ -5940,40 +5947,48 @@ const def$c = {
         if (max === undefined && min === 1) {
             validateItems(valid, () => gen.if(valid, () => gen.break()));
         }
+        else if (min === 0) {
+            gen.let(valid, true);
+            if (max !== undefined)
+                gen.if((0, codegen_1$b._) `${data}.length > 0`, validateItemsWithCount);
+        }
         else {
             gen.let(valid, false);
+            validateItemsWithCount();
+        }
+        cxt.result(valid, () => cxt.reset());
+        function validateItemsWithCount() {
             const schValid = gen.name("_valid");
             const count = gen.let("count", 0);
             validateItems(schValid, () => gen.if(schValid, () => checkLimits(count)));
         }
-        cxt.result(valid, () => cxt.reset());
         function validateItems(_valid, block) {
             gen.forRange("i", 0, len, (i) => {
                 cxt.subschema({
                     keyword: "contains",
                     dataProp: i,
-                    dataPropType: util_1$9.Type.Num,
+                    dataPropType: util_1$d.Type.Num,
                     compositeRule: true,
                 }, _valid);
                 block();
             });
         }
         function checkLimits(count) {
-            gen.code(codegen_1$7._ `${count}++`);
+            gen.code((0, codegen_1$b._) `${count}++`);
             if (max === undefined) {
-                gen.if(codegen_1$7._ `${count} >= ${min}`, () => gen.assign(valid, true).break());
+                gen.if((0, codegen_1$b._) `${count} >= ${min}`, () => gen.assign(valid, true).break());
             }
             else {
-                gen.if(codegen_1$7._ `${count} > ${max}`, () => gen.assign(valid, false).break());
+                gen.if((0, codegen_1$b._) `${count} > ${max}`, () => gen.assign(valid, false).break());
                 if (min === 1)
                     gen.assign(valid, true);
                 else
-                    gen.if(codegen_1$7._ `${count} >= ${min}`, () => gen.assign(valid, true));
+                    gen.if((0, codegen_1$b._) `${count} >= ${min}`, () => gen.assign(valid, true));
             }
         }
     },
 };
-contains.default = def$c;
+contains.default = def$l;
 
 var dependencies = {};
 
@@ -5986,9 +6001,9 @@ const code_1 = code;
 exports.error = {
     message: ({ params: { property, depsCount, deps } }) => {
         const property_ies = depsCount === 1 ? "property" : "properties";
-        return codegen_1.str `must have ${property_ies} ${deps} when property ${property} is present`;
+        return (0, codegen_1.str) `must have ${property_ies} ${deps} when property ${property} is present`;
     },
-    params: ({ params: { property, depsCount, deps, missingProperty } }) => codegen_1._ `{property: ${property},
+    params: ({ params: { property, depsCount, deps, missingProperty } }) => (0, codegen_1._) `{property: ${property},
     missingProperty: ${missingProperty},
     depsCount: ${depsCount},
     deps: ${deps}}`, // TODO change to reference
@@ -6024,7 +6039,7 @@ function validatePropertyDeps(cxt, propertyDeps = cxt.schema) {
         const deps = propertyDeps[prop];
         if (deps.length === 0)
             continue;
-        const hasProperty = code_1.propertyInData(gen, data, prop, it.opts.ownProperties);
+        const hasProperty = (0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties);
         cxt.setParams({
             property: prop,
             depsCount: deps.length,
@@ -6033,13 +6048,13 @@ function validatePropertyDeps(cxt, propertyDeps = cxt.schema) {
         if (it.allErrors) {
             gen.if(hasProperty, () => {
                 for (const depProp of deps) {
-                    code_1.checkReportMissingProp(cxt, depProp);
+                    (0, code_1.checkReportMissingProp)(cxt, depProp);
                 }
             });
         }
         else {
-            gen.if(codegen_1._ `${hasProperty} && (${code_1.checkMissingProp(cxt, deps, missing)})`);
-            code_1.reportMissingProp(cxt, missing);
+            gen.if((0, codegen_1._) `${hasProperty} && (${(0, code_1.checkMissingProp)(cxt, deps, missing)})`);
+            (0, code_1.reportMissingProp)(cxt, missing);
             gen.else();
         }
     }
@@ -6049,9 +6064,9 @@ function validateSchemaDeps(cxt, schemaDeps = cxt.schema) {
     const { gen, data, keyword, it } = cxt;
     const valid = gen.name("valid");
     for (const prop in schemaDeps) {
-        if (util_1.alwaysValidSchema(it, schemaDeps[prop]))
+        if ((0, util_1.alwaysValidSchema)(it, schemaDeps[prop]))
             continue;
-        gen.if(code_1.propertyInData(gen, data, prop, it.opts.ownProperties), () => {
+        gen.if((0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties), () => {
             const schCxt = cxt.subschema({ keyword, schemaProp: prop }, valid);
             cxt.mergeValidEvaluated(schCxt, valid);
         }, () => gen.var(valid, true) // TODO var
@@ -6067,20 +6082,20 @@ exports.default = def;
 var propertyNames = {};
 
 Object.defineProperty(propertyNames, "__esModule", { value: true });
-const codegen_1$6 = codegen;
-const util_1$8 = util;
-const error$5 = {
+const codegen_1$a = codegen;
+const util_1$c = util;
+const error$7 = {
     message: "property name must be valid",
-    params: ({ params }) => codegen_1$6._ `{propertyName: ${params.propertyName}}`,
+    params: ({ params }) => (0, codegen_1$a._) `{propertyName: ${params.propertyName}}`,
 };
-const def$b = {
+const def$k = {
     keyword: "propertyNames",
     type: "object",
     schemaType: ["object", "boolean"],
-    error: error$5,
+    error: error$7,
     code(cxt) {
         const { gen, schema, data, it } = cxt;
-        if (util_1$8.alwaysValidSchema(it, schema))
+        if ((0, util_1$c.alwaysValidSchema)(it, schema))
             return;
         const valid = gen.name("valid");
         gen.forIn("key", data, (key) => {
@@ -6092,7 +6107,7 @@ const def$b = {
                 propertyName: key,
                 compositeRule: true,
             }, valid);
-            gen.if(codegen_1$6.not(valid), () => {
+            gen.if((0, codegen_1$a.not)(valid), () => {
                 cxt.error(true);
                 if (!it.allErrors)
                     gen.break();
@@ -6101,26 +6116,26 @@ const def$b = {
         cxt.ok(valid);
     },
 };
-propertyNames.default = def$b;
+propertyNames.default = def$k;
 
 var additionalProperties$h = {};
 
 Object.defineProperty(additionalProperties$h, "__esModule", { value: true });
 const code_1$3 = code;
-const codegen_1$5 = codegen;
-const names_1 = names$1;
-const util_1$7 = util;
-const error$4 = {
+const codegen_1$9 = codegen;
+const names_1$3 = names$1;
+const util_1$b = util;
+const error$6 = {
     message: "must NOT have additional properties",
-    params: ({ params }) => codegen_1$5._ `{additionalProperty: ${params.additionalProperty}}`,
+    params: ({ params }) => (0, codegen_1$9._) `{additionalProperty: ${params.additionalProperty}}`,
 };
-const def$a = {
+const def$j = {
     keyword: "additionalProperties",
     type: ["object"],
     schemaType: ["boolean", "object"],
     allowUndefined: true,
     trackErrors: true,
-    error: error$4,
+    error: error$6,
     code(cxt) {
         const { gen, schema, parentSchema, data, errsCount, it } = cxt;
         /* istanbul ignore if */
@@ -6128,12 +6143,12 @@ const def$a = {
             throw new Error("ajv implementation error");
         const { allErrors, opts } = it;
         it.props = true;
-        if (opts.removeAdditional !== "all" && util_1$7.alwaysValidSchema(it, schema))
+        if (opts.removeAdditional !== "all" && (0, util_1$b.alwaysValidSchema)(it, schema))
             return;
-        const props = code_1$3.allSchemaProperties(parentSchema.properties);
-        const patProps = code_1$3.allSchemaProperties(parentSchema.patternProperties);
+        const props = (0, code_1$3.allSchemaProperties)(parentSchema.properties);
+        const patProps = (0, code_1$3.allSchemaProperties)(parentSchema.patternProperties);
         checkAdditionalProperties();
-        cxt.ok(codegen_1$5._ `${errsCount} === ${names_1.default.errors}`);
+        cxt.ok((0, codegen_1$9._) `${errsCount} === ${names_1$3.default.errors}`);
         function checkAdditionalProperties() {
             gen.forIn("key", data, (key) => {
                 if (!props.length && !patProps.length)
@@ -6146,22 +6161,22 @@ const def$a = {
             let definedProp;
             if (props.length > 8) {
                 // TODO maybe an option instead of hard-coded 8?
-                const propsSchema = util_1$7.schemaRefOrVal(it, parentSchema.properties, "properties");
-                definedProp = code_1$3.isOwnProperty(gen, propsSchema, key);
+                const propsSchema = (0, util_1$b.schemaRefOrVal)(it, parentSchema.properties, "properties");
+                definedProp = (0, code_1$3.isOwnProperty)(gen, propsSchema, key);
             }
             else if (props.length) {
-                definedProp = codegen_1$5.or(...props.map((p) => codegen_1$5._ `${key} === ${p}`));
+                definedProp = (0, codegen_1$9.or)(...props.map((p) => (0, codegen_1$9._) `${key} === ${p}`));
             }
             else {
-                definedProp = codegen_1$5.nil;
+                definedProp = codegen_1$9.nil;
             }
             if (patProps.length) {
-                definedProp = codegen_1$5.or(definedProp, ...patProps.map((p) => codegen_1$5._ `${code_1$3.usePattern(cxt, p)}.test(${key})`));
+                definedProp = (0, codegen_1$9.or)(definedProp, ...patProps.map((p) => (0, codegen_1$9._) `${(0, code_1$3.usePattern)(cxt, p)}.test(${key})`));
             }
-            return codegen_1$5.not(definedProp);
+            return (0, codegen_1$9.not)(definedProp);
         }
         function deleteAdditional(key) {
-            gen.code(codegen_1$5._ `delete ${data}[${key}]`);
+            gen.code((0, codegen_1$9._) `delete ${data}[${key}]`);
         }
         function additionalPropertyCode(key) {
             if (opts.removeAdditional === "all" || (opts.removeAdditional && schema === false)) {
@@ -6175,11 +6190,11 @@ const def$a = {
                     gen.break();
                 return;
             }
-            if (typeof schema == "object" && !util_1$7.alwaysValidSchema(it, schema)) {
+            if (typeof schema == "object" && !(0, util_1$b.alwaysValidSchema)(it, schema)) {
                 const valid = gen.name("valid");
                 if (opts.removeAdditional === "failing") {
                     applyAdditionalSchema(key, valid, false);
-                    gen.if(codegen_1$5.not(valid), () => {
+                    gen.if((0, codegen_1$9.not)(valid), () => {
                         cxt.reset();
                         deleteAdditional(key);
                     });
@@ -6187,7 +6202,7 @@ const def$a = {
                 else {
                     applyAdditionalSchema(key, valid);
                     if (!allErrors)
-                        gen.if(codegen_1$5.not(valid), () => gen.break());
+                        gen.if((0, codegen_1$9.not)(valid), () => gen.break());
                 }
             }
         }
@@ -6195,7 +6210,7 @@ const def$a = {
             const subschema = {
                 keyword: "additionalProperties",
                 dataProp: key,
-                dataPropType: util_1$7.Type.Str,
+                dataPropType: util_1$b.Type.Str,
             };
             if (errors === false) {
                 Object.assign(subschema, {
@@ -6208,16 +6223,16 @@ const def$a = {
         }
     },
 };
-additionalProperties$h.default = def$a;
+additionalProperties$h.default = def$j;
 
-var properties$i = {};
+var properties$p = {};
 
-Object.defineProperty(properties$i, "__esModule", { value: true });
+Object.defineProperty(properties$p, "__esModule", { value: true });
 const validate_1 = validate;
 const code_1$2 = code;
-const util_1$6 = util;
+const util_1$a = util;
 const additionalProperties_1$1 = additionalProperties$h;
-const def$9 = {
+const def$i = {
     keyword: "properties",
     type: "object",
     schemaType: "object",
@@ -6226,14 +6241,14 @@ const def$9 = {
         if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
             additionalProperties_1$1.default.code(new validate_1.KeywordCxt(it, additionalProperties_1$1.default, "additionalProperties"));
         }
-        const allProps = code_1$2.allSchemaProperties(schema);
+        const allProps = (0, code_1$2.allSchemaProperties)(schema);
         for (const prop of allProps) {
             it.definedProperties.add(prop);
         }
         if (it.opts.unevaluated && allProps.length && it.props !== true) {
-            it.props = util_1$6.mergeEvaluated.props(gen, util_1$6.toHash(allProps), it.props);
+            it.props = util_1$a.mergeEvaluated.props(gen, (0, util_1$a.toHash)(allProps), it.props);
         }
-        const properties = allProps.filter((p) => !util_1$6.alwaysValidSchema(it, schema[p]));
+        const properties = allProps.filter((p) => !(0, util_1$a.alwaysValidSchema)(it, schema[p]));
         if (properties.length === 0)
             return;
         const valid = gen.name("valid");
@@ -6242,7 +6257,7 @@ const def$9 = {
                 applyPropertySchema(prop);
             }
             else {
-                gen.if(code_1$2.propertyInData(gen, data, prop, it.opts.ownProperties));
+                gen.if((0, code_1$2.propertyInData)(gen, data, prop, it.opts.ownProperties));
                 applyPropertySchema(prop);
                 if (!it.allErrors)
                     gen.else().var(valid, true);
@@ -6263,24 +6278,24 @@ const def$9 = {
         }
     },
 };
-properties$i.default = def$9;
+properties$p.default = def$i;
 
 var patternProperties = {};
 
 Object.defineProperty(patternProperties, "__esModule", { value: true });
 const code_1$1 = code;
-const codegen_1$4 = codegen;
-const util_1$5 = util;
+const codegen_1$8 = codegen;
+const util_1$9 = util;
 const util_2 = util;
-const def$8 = {
+const def$h = {
     keyword: "patternProperties",
     type: "object",
     schemaType: "object",
     code(cxt) {
         const { gen, schema, data, parentSchema, it } = cxt;
         const { opts } = it;
-        const patterns = code_1$1.allSchemaProperties(schema);
-        const alwaysValidPatterns = patterns.filter((p) => util_1$5.alwaysValidSchema(it, schema[p]));
+        const patterns = (0, code_1$1.allSchemaProperties)(schema);
+        const alwaysValidPatterns = patterns.filter((p) => (0, util_1$9.alwaysValidSchema)(it, schema[p]));
         if (patterns.length === 0 ||
             (alwaysValidPatterns.length === patterns.length &&
                 (!it.opts.unevaluated || it.props === true))) {
@@ -6288,8 +6303,8 @@ const def$8 = {
         }
         const checkProperties = opts.strictSchema && !opts.allowMatchingProperties && parentSchema.properties;
         const valid = gen.name("valid");
-        if (it.props !== true && !(it.props instanceof codegen_1$4.Name)) {
-            it.props = util_2.evaluatedPropsToName(gen, it.props);
+        if (it.props !== true && !(it.props instanceof codegen_1$8.Name)) {
+            it.props = (0, util_2.evaluatedPropsToName)(gen, it.props);
         }
         const { props } = it;
         validatePatternProperties();
@@ -6310,13 +6325,13 @@ const def$8 = {
         function checkMatchingProperties(pat) {
             for (const prop in checkProperties) {
                 if (new RegExp(pat).test(prop)) {
-                    util_1$5.checkStrictMode(it, `property ${prop} matches pattern ${pat} (use allowMatchingProperties)`);
+                    (0, util_1$9.checkStrictMode)(it, `property ${prop} matches pattern ${pat} (use allowMatchingProperties)`);
                 }
             }
         }
         function validateProperties(pat) {
             gen.forIn("key", data, (key) => {
-                gen.if(codegen_1$4._ `${code_1$1.usePattern(cxt, pat)}.test(${key})`, () => {
+                gen.if((0, codegen_1$8._) `${(0, code_1$1.usePattern)(cxt, pat)}.test(${key})`, () => {
                     const alwaysValid = alwaysValidPatterns.includes(pat);
                     if (!alwaysValid) {
                         cxt.subschema({
@@ -6327,31 +6342,31 @@ const def$8 = {
                         }, valid);
                     }
                     if (it.opts.unevaluated && props !== true) {
-                        gen.assign(codegen_1$4._ `${props}[${key}]`, true);
+                        gen.assign((0, codegen_1$8._) `${props}[${key}]`, true);
                     }
                     else if (!alwaysValid && !it.allErrors) {
                         // can short-circuit if `unevaluatedProperties` is not supported (opts.next === false)
                         // or if all properties were evaluated (props === true)
-                        gen.if(codegen_1$4.not(valid), () => gen.break());
+                        gen.if((0, codegen_1$8.not)(valid), () => gen.break());
                     }
                 });
             });
         }
     },
 };
-patternProperties.default = def$8;
+patternProperties.default = def$h;
 
 var not = {};
 
 Object.defineProperty(not, "__esModule", { value: true });
-const util_1$4 = util;
-const def$7 = {
+const util_1$8 = util;
+const def$g = {
     keyword: "not",
     schemaType: ["object", "boolean"],
     trackErrors: true,
     code(cxt) {
         const { gen, schema, it } = cxt;
-        if (util_1$4.alwaysValidSchema(it, schema)) {
+        if ((0, util_1$8.alwaysValidSchema)(it, schema)) {
             cxt.fail();
             return;
         }
@@ -6366,35 +6381,35 @@ const def$7 = {
     },
     error: { message: "must NOT be valid" },
 };
-not.default = def$7;
+not.default = def$g;
 
 var anyOf = {};
 
 Object.defineProperty(anyOf, "__esModule", { value: true });
 const code_1 = code;
-const def$6 = {
+const def$f = {
     keyword: "anyOf",
     schemaType: "array",
     trackErrors: true,
     code: code_1.validateUnion,
     error: { message: "must match a schema in anyOf" },
 };
-anyOf.default = def$6;
+anyOf.default = def$f;
 
 var oneOf$1 = {};
 
 Object.defineProperty(oneOf$1, "__esModule", { value: true });
-const codegen_1$3 = codegen;
-const util_1$3 = util;
-const error$3 = {
+const codegen_1$7 = codegen;
+const util_1$7 = util;
+const error$5 = {
     message: "must match exactly one schema in oneOf",
-    params: ({ params }) => codegen_1$3._ `{passingSchemas: ${params.passing}}`,
+    params: ({ params }) => (0, codegen_1$7._) `{passingSchemas: ${params.passing}}`,
 };
-const def$5 = {
+const def$e = {
     keyword: "oneOf",
     schemaType: "array",
     trackErrors: true,
-    error: error$3,
+    error: error$5,
     code(cxt) {
         const { gen, schema, parentSchema, it } = cxt;
         /* istanbul ignore if */
@@ -6413,7 +6428,7 @@ const def$5 = {
         function validateOneOf() {
             schArr.forEach((sch, i) => {
                 let schCxt;
-                if (util_1$3.alwaysValidSchema(it, sch)) {
+                if ((0, util_1$7.alwaysValidSchema)(it, sch)) {
                     gen.var(schValid, true);
                 }
                 else {
@@ -6425,28 +6440,28 @@ const def$5 = {
                 }
                 if (i > 0) {
                     gen
-                        .if(codegen_1$3._ `${schValid} && ${valid}`)
+                        .if((0, codegen_1$7._) `${schValid} && ${valid}`)
                         .assign(valid, false)
-                        .assign(passing, codegen_1$3._ `[${passing}, ${i}]`)
+                        .assign(passing, (0, codegen_1$7._) `[${passing}, ${i}]`)
                         .else();
                 }
                 gen.if(schValid, () => {
                     gen.assign(valid, true);
                     gen.assign(passing, i);
                     if (schCxt)
-                        cxt.mergeEvaluated(schCxt, codegen_1$3.Name);
+                        cxt.mergeEvaluated(schCxt, codegen_1$7.Name);
                 });
             });
         }
     },
 };
-oneOf$1.default = def$5;
+oneOf$1.default = def$e;
 
-var allOf = {};
+var allOf$1 = {};
 
-Object.defineProperty(allOf, "__esModule", { value: true });
-const util_1$2 = util;
-const def$4 = {
+Object.defineProperty(allOf$1, "__esModule", { value: true });
+const util_1$6 = util;
+const def$d = {
     keyword: "allOf",
     schemaType: "array",
     code(cxt) {
@@ -6456,7 +6471,7 @@ const def$4 = {
             throw new Error("ajv implementation error");
         const valid = gen.name("valid");
         schema.forEach((sch, i) => {
-            if (util_1$2.alwaysValidSchema(it, sch))
+            if ((0, util_1$6.alwaysValidSchema)(it, sch))
                 return;
             const schCxt = cxt.subschema({ keyword: "allOf", schemaProp: i }, valid);
             cxt.ok(valid);
@@ -6464,26 +6479,26 @@ const def$4 = {
         });
     },
 };
-allOf.default = def$4;
+allOf$1.default = def$d;
 
 var _if = {};
 
 Object.defineProperty(_if, "__esModule", { value: true });
-const codegen_1$2 = codegen;
-const util_1$1 = util;
-const error$2 = {
-    message: ({ params }) => codegen_1$2.str `must match "${params.ifClause}" schema`,
-    params: ({ params }) => codegen_1$2._ `{failingKeyword: ${params.ifClause}}`,
+const codegen_1$6 = codegen;
+const util_1$5 = util;
+const error$4 = {
+    message: ({ params }) => (0, codegen_1$6.str) `must match "${params.ifClause}" schema`,
+    params: ({ params }) => (0, codegen_1$6._) `{failingKeyword: ${params.ifClause}}`,
 };
-const def$3 = {
+const def$c = {
     keyword: "if",
     schemaType: ["object", "boolean"],
     trackErrors: true,
-    error: error$2,
+    error: error$4,
     code(cxt) {
         const { gen, parentSchema, it } = cxt;
         if (parentSchema.then === undefined && parentSchema.else === undefined) {
-            util_1$1.checkStrictMode(it, '"if" without "then" and "else" is ignored');
+            (0, util_1$5.checkStrictMode)(it, '"if" without "then" and "else" is ignored');
         }
         const hasThen = hasSchema(it, "then");
         const hasElse = hasSchema(it, "else");
@@ -6502,7 +6517,7 @@ const def$3 = {
             gen.if(schValid, validateClause("then"));
         }
         else {
-            gen.if(codegen_1$2.not(schValid), validateClause("else"));
+            gen.if((0, codegen_1$6.not)(schValid), validateClause("else"));
         }
         cxt.pass(valid, () => cxt.error(true));
         function validateIf() {
@@ -6520,7 +6535,7 @@ const def$3 = {
                 gen.assign(valid, schValid);
                 cxt.mergeValidEvaluated(schCxt, valid);
                 if (ifClause)
-                    gen.assign(ifClause, codegen_1$2._ `${keyword}`);
+                    gen.assign(ifClause, (0, codegen_1$6._) `${keyword}`);
                 else
                     cxt.setParams({ ifClause: keyword });
             };
@@ -6529,39 +6544,39 @@ const def$3 = {
 };
 function hasSchema(it, keyword) {
     const schema = it.schema[keyword];
-    return schema !== undefined && !util_1$1.alwaysValidSchema(it, schema);
+    return schema !== undefined && !(0, util_1$5.alwaysValidSchema)(it, schema);
 }
-_if.default = def$3;
+_if.default = def$c;
 
 var thenElse = {};
 
 Object.defineProperty(thenElse, "__esModule", { value: true });
-const util_1 = util;
-const def$2 = {
+const util_1$4 = util;
+const def$b = {
     keyword: ["then", "else"],
     schemaType: ["object", "boolean"],
     code({ keyword, parentSchema, it }) {
         if (parentSchema.if === undefined)
-            util_1.checkStrictMode(it, `"${keyword}" without "if" is ignored`);
+            (0, util_1$4.checkStrictMode)(it, `"${keyword}" without "if" is ignored`);
     },
 };
-thenElse.default = def$2;
+thenElse.default = def$b;
 
-Object.defineProperty(applicator, "__esModule", { value: true });
+Object.defineProperty(applicator$1, "__esModule", { value: true });
 const additionalItems_1 = additionalItems;
 const prefixItems_1 = prefixItems;
 const items_1 = items;
 const items2020_1 = items2020;
 const contains_1 = contains;
-const dependencies_1 = dependencies;
+const dependencies_1$2 = dependencies;
 const propertyNames_1 = propertyNames;
 const additionalProperties_1 = additionalProperties$h;
-const properties_1 = properties$i;
+const properties_1 = properties$p;
 const patternProperties_1 = patternProperties;
 const not_1 = not;
 const anyOf_1 = anyOf;
 const oneOf_1 = oneOf$1;
-const allOf_1 = allOf;
+const allOf_1 = allOf$1;
 const if_1 = _if;
 const thenElse_1 = thenElse;
 function getApplicator(draft2020 = false) {
@@ -6576,7 +6591,7 @@ function getApplicator(draft2020 = false) {
         // object
         propertyNames_1.default,
         additionalProperties_1.default,
-        dependencies_1.default,
+        dependencies_1$2.default,
         properties_1.default,
         patternProperties_1.default,
     ];
@@ -6588,17 +6603,303 @@ function getApplicator(draft2020 = false) {
     applicator.push(contains_1.default);
     return applicator;
 }
-applicator.default = getApplicator;
+applicator$1.default = getApplicator;
+
+var dynamic$1 = {};
+
+var dynamicAnchor$1 = {};
+
+Object.defineProperty(dynamicAnchor$1, "__esModule", { value: true });
+dynamicAnchor$1.dynamicAnchor = void 0;
+const codegen_1$5 = codegen;
+const names_1$2 = names$1;
+const compile_1 = compile;
+const ref_1$1 = ref;
+const def$a = {
+    keyword: "$dynamicAnchor",
+    schemaType: "string",
+    code: (cxt) => dynamicAnchor(cxt, cxt.schema),
+};
+function dynamicAnchor(cxt, anchor) {
+    const { gen, it } = cxt;
+    it.schemaEnv.root.dynamicAnchors[anchor] = true;
+    const v = (0, codegen_1$5._) `${names_1$2.default.dynamicAnchors}${(0, codegen_1$5.getProperty)(anchor)}`;
+    const validate = it.errSchemaPath === "#" ? it.validateName : _getValidate(cxt);
+    gen.if((0, codegen_1$5._) `!${v}`, () => gen.assign(v, validate));
+}
+dynamicAnchor$1.dynamicAnchor = dynamicAnchor;
+function _getValidate(cxt) {
+    const { schemaEnv, schema, self } = cxt.it;
+    const { root, baseId, localRefs, meta } = schemaEnv.root;
+    const { schemaId } = self.opts;
+    const sch = new compile_1.SchemaEnv({ schema, schemaId, root, baseId, localRefs, meta });
+    compile_1.compileSchema.call(self, sch);
+    return (0, ref_1$1.getValidate)(cxt, sch);
+}
+dynamicAnchor$1.default = def$a;
+
+var dynamicRef$1 = {};
+
+Object.defineProperty(dynamicRef$1, "__esModule", { value: true });
+dynamicRef$1.dynamicRef = void 0;
+const codegen_1$4 = codegen;
+const names_1$1 = names$1;
+const ref_1 = ref;
+const def$9 = {
+    keyword: "$dynamicRef",
+    schemaType: "string",
+    code: (cxt) => dynamicRef(cxt, cxt.schema),
+};
+function dynamicRef(cxt, ref) {
+    const { gen, keyword, it } = cxt;
+    if (ref[0] !== "#")
+        throw new Error(`"${keyword}" only supports hash fragment reference`);
+    const anchor = ref.slice(1);
+    if (it.allErrors) {
+        _dynamicRef();
+    }
+    else {
+        const valid = gen.let("valid", false);
+        _dynamicRef(valid);
+        cxt.ok(valid);
+    }
+    function _dynamicRef(valid) {
+        // TODO the assumption here is that `recursiveRef: #` always points to the root
+        // of the schema object, which is not correct, because there may be $id that
+        // makes # point to it, and the target schema may not contain dynamic/recursiveAnchor.
+        // Because of that 2 tests in recursiveRef.json fail.
+        // This is a similar problem to #815 (`$id` doesn't alter resolution scope for `{ "$ref": "#" }`).
+        // (This problem is not tested in JSON-Schema-Test-Suite)
+        if (it.schemaEnv.root.dynamicAnchors[anchor]) {
+            const v = gen.let("_v", (0, codegen_1$4._) `${names_1$1.default.dynamicAnchors}${(0, codegen_1$4.getProperty)(anchor)}`);
+            gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid));
+        }
+        else {
+            _callRef(it.validateName, valid)();
+        }
+    }
+    function _callRef(validate, valid) {
+        return valid
+            ? () => gen.block(() => {
+                (0, ref_1.callRef)(cxt, validate);
+                gen.let(valid, true);
+            })
+            : () => (0, ref_1.callRef)(cxt, validate);
+    }
+}
+dynamicRef$1.dynamicRef = dynamicRef;
+dynamicRef$1.default = def$9;
+
+var recursiveAnchor = {};
+
+Object.defineProperty(recursiveAnchor, "__esModule", { value: true });
+const dynamicAnchor_1$1 = dynamicAnchor$1;
+const util_1$3 = util;
+const def$8 = {
+    keyword: "$recursiveAnchor",
+    schemaType: "boolean",
+    code(cxt) {
+        if (cxt.schema)
+            (0, dynamicAnchor_1$1.dynamicAnchor)(cxt, "");
+        else
+            (0, util_1$3.checkStrictMode)(cxt.it, "$recursiveAnchor: false is ignored");
+    },
+};
+recursiveAnchor.default = def$8;
+
+var recursiveRef = {};
+
+Object.defineProperty(recursiveRef, "__esModule", { value: true });
+const dynamicRef_1$1 = dynamicRef$1;
+const def$7 = {
+    keyword: "$recursiveRef",
+    schemaType: "string",
+    code: (cxt) => (0, dynamicRef_1$1.dynamicRef)(cxt, cxt.schema),
+};
+recursiveRef.default = def$7;
+
+Object.defineProperty(dynamic$1, "__esModule", { value: true });
+const dynamicAnchor_1 = dynamicAnchor$1;
+const dynamicRef_1 = dynamicRef$1;
+const recursiveAnchor_1 = recursiveAnchor;
+const recursiveRef_1 = recursiveRef;
+const dynamic = [dynamicAnchor_1.default, dynamicRef_1.default, recursiveAnchor_1.default, recursiveRef_1.default];
+dynamic$1.default = dynamic;
+
+var next$1 = {};
+
+var dependentRequired = {};
+
+Object.defineProperty(dependentRequired, "__esModule", { value: true });
+const dependencies_1$1 = dependencies;
+const def$6 = {
+    keyword: "dependentRequired",
+    type: "object",
+    schemaType: "object",
+    error: dependencies_1$1.error,
+    code: (cxt) => (0, dependencies_1$1.validatePropertyDeps)(cxt),
+};
+dependentRequired.default = def$6;
+
+var dependentSchemas = {};
+
+Object.defineProperty(dependentSchemas, "__esModule", { value: true });
+const dependencies_1 = dependencies;
+const def$5 = {
+    keyword: "dependentSchemas",
+    type: "object",
+    schemaType: "object",
+    code: (cxt) => (0, dependencies_1.validateSchemaDeps)(cxt),
+};
+dependentSchemas.default = def$5;
+
+var limitContains = {};
+
+Object.defineProperty(limitContains, "__esModule", { value: true });
+const util_1$2 = util;
+const def$4 = {
+    keyword: ["maxContains", "minContains"],
+    type: "array",
+    schemaType: "number",
+    code({ keyword, parentSchema, it }) {
+        if (parentSchema.contains === undefined) {
+            (0, util_1$2.checkStrictMode)(it, `"${keyword}" without "contains" is ignored`);
+        }
+    },
+};
+limitContains.default = def$4;
+
+Object.defineProperty(next$1, "__esModule", { value: true });
+const dependentRequired_1 = dependentRequired;
+const dependentSchemas_1 = dependentSchemas;
+const limitContains_1 = limitContains;
+const next = [dependentRequired_1.default, dependentSchemas_1.default, limitContains_1.default];
+next$1.default = next;
+
+var unevaluated$2 = {};
+
+var unevaluatedProperties = {};
+
+Object.defineProperty(unevaluatedProperties, "__esModule", { value: true });
+const codegen_1$3 = codegen;
+const util_1$1 = util;
+const names_1 = names$1;
+const error$3 = {
+    message: "must NOT have unevaluated properties",
+    params: ({ params }) => (0, codegen_1$3._) `{unevaluatedProperty: ${params.unevaluatedProperty}}`,
+};
+const def$3 = {
+    keyword: "unevaluatedProperties",
+    type: "object",
+    schemaType: ["boolean", "object"],
+    trackErrors: true,
+    error: error$3,
+    code(cxt) {
+        const { gen, schema, data, errsCount, it } = cxt;
+        /* istanbul ignore if */
+        if (!errsCount)
+            throw new Error("ajv implementation error");
+        const { allErrors, props } = it;
+        if (props instanceof codegen_1$3.Name) {
+            gen.if((0, codegen_1$3._) `${props} !== true`, () => gen.forIn("key", data, (key) => gen.if(unevaluatedDynamic(props, key), () => unevaluatedPropCode(key))));
+        }
+        else if (props !== true) {
+            gen.forIn("key", data, (key) => props === undefined
+                ? unevaluatedPropCode(key)
+                : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key)));
+        }
+        it.props = true;
+        cxt.ok((0, codegen_1$3._) `${errsCount} === ${names_1.default.errors}`);
+        function unevaluatedPropCode(key) {
+            if (schema === false) {
+                cxt.setParams({ unevaluatedProperty: key });
+                cxt.error();
+                if (!allErrors)
+                    gen.break();
+                return;
+            }
+            if (!(0, util_1$1.alwaysValidSchema)(it, schema)) {
+                const valid = gen.name("valid");
+                cxt.subschema({
+                    keyword: "unevaluatedProperties",
+                    dataProp: key,
+                    dataPropType: util_1$1.Type.Str,
+                }, valid);
+                if (!allErrors)
+                    gen.if((0, codegen_1$3.not)(valid), () => gen.break());
+            }
+        }
+        function unevaluatedDynamic(evaluatedProps, key) {
+            return (0, codegen_1$3._) `!${evaluatedProps} || !${evaluatedProps}[${key}]`;
+        }
+        function unevaluatedStatic(evaluatedProps, key) {
+            const ps = [];
+            for (const p in evaluatedProps) {
+                if (evaluatedProps[p] === true)
+                    ps.push((0, codegen_1$3._) `${key} !== ${p}`);
+            }
+            return (0, codegen_1$3.and)(...ps);
+        }
+    },
+};
+unevaluatedProperties.default = def$3;
+
+var unevaluatedItems = {};
+
+Object.defineProperty(unevaluatedItems, "__esModule", { value: true });
+const codegen_1$2 = codegen;
+const util_1 = util;
+const error$2 = {
+    message: ({ params: { len } }) => (0, codegen_1$2.str) `must NOT have more than ${len} items`,
+    params: ({ params: { len } }) => (0, codegen_1$2._) `{limit: ${len}}`,
+};
+const def$2 = {
+    keyword: "unevaluatedItems",
+    type: "array",
+    schemaType: ["boolean", "object"],
+    error: error$2,
+    code(cxt) {
+        const { gen, schema, data, it } = cxt;
+        const items = it.items || 0;
+        if (items === true)
+            return;
+        const len = gen.const("len", (0, codegen_1$2._) `${data}.length`);
+        if (schema === false) {
+            cxt.setParams({ len: items });
+            cxt.fail((0, codegen_1$2._) `${len} > ${items}`);
+        }
+        else if (typeof schema == "object" && !(0, util_1.alwaysValidSchema)(it, schema)) {
+            const valid = gen.var("valid", (0, codegen_1$2._) `${len} <= ${items}`);
+            gen.if((0, codegen_1$2.not)(valid), () => validateItems(valid, items));
+            cxt.ok(valid);
+        }
+        it.items = true;
+        function validateItems(valid, from) {
+            gen.forRange("i", from, len, (i) => {
+                cxt.subschema({ keyword: "unevaluatedItems", dataProp: i, dataPropType: util_1.Type.Num }, valid);
+                if (!it.allErrors)
+                    gen.if((0, codegen_1$2.not)(valid), () => gen.break());
+            });
+        }
+    },
+};
+unevaluatedItems.default = def$2;
+
+Object.defineProperty(unevaluated$2, "__esModule", { value: true });
+const unevaluatedProperties_1 = unevaluatedProperties;
+const unevaluatedItems_1 = unevaluatedItems;
+const unevaluated$1 = [unevaluatedProperties_1.default, unevaluatedItems_1.default];
+unevaluated$2.default = unevaluated$1;
+
+var format$3 = {};
 
 var format$2 = {};
 
-var format$1 = {};
-
-Object.defineProperty(format$1, "__esModule", { value: true });
+Object.defineProperty(format$2, "__esModule", { value: true });
 const codegen_1$1 = codegen;
 const error$1 = {
-    message: ({ schemaCode }) => codegen_1$1.str `must match format "${schemaCode}"`,
-    params: ({ schemaCode }) => codegen_1$1._ `{format: ${schemaCode}}`,
+    message: ({ schemaCode }) => (0, codegen_1$1.str) `must match format "${schemaCode}"`,
+    params: ({ schemaCode }) => (0, codegen_1$1._) `{format: ${schemaCode}}`,
 };
 const def$1 = {
     keyword: "format",
@@ -6620,23 +6921,23 @@ const def$1 = {
                 ref: self.formats,
                 code: opts.code.formats,
             });
-            const fDef = gen.const("fDef", codegen_1$1._ `${fmts}[${schemaCode}]`);
+            const fDef = gen.const("fDef", (0, codegen_1$1._) `${fmts}[${schemaCode}]`);
             const fType = gen.let("fType");
             const format = gen.let("format");
             // TODO simplify
-            gen.if(codegen_1$1._ `typeof ${fDef} == "object" && !(${fDef} instanceof RegExp)`, () => gen.assign(fType, codegen_1$1._ `${fDef}.type || "string"`).assign(format, codegen_1$1._ `${fDef}.validate`), () => gen.assign(fType, codegen_1$1._ `"string"`).assign(format, fDef));
-            cxt.fail$data(codegen_1$1.or(unknownFmt(), invalidFmt()));
+            gen.if((0, codegen_1$1._) `typeof ${fDef} == "object" && !(${fDef} instanceof RegExp)`, () => gen.assign(fType, (0, codegen_1$1._) `${fDef}.type || "string"`).assign(format, (0, codegen_1$1._) `${fDef}.validate`), () => gen.assign(fType, (0, codegen_1$1._) `"string"`).assign(format, fDef));
+            cxt.fail$data((0, codegen_1$1.or)(unknownFmt(), invalidFmt()));
             function unknownFmt() {
                 if (opts.strictSchema === false)
                     return codegen_1$1.nil;
-                return codegen_1$1._ `${schemaCode} && !${format}`;
+                return (0, codegen_1$1._) `${schemaCode} && !${format}`;
             }
             function invalidFmt() {
                 const callFormat = schemaEnv.$async
-                    ? codegen_1$1._ `(${fDef}.async ? await ${format}(${data}) : ${format}(${data}))`
-                    : codegen_1$1._ `${format}(${data})`;
-                const validData = codegen_1$1._ `(typeof ${format} == "function" ? ${callFormat} : ${format}.test(${data}))`;
-                return codegen_1$1._ `${format} && ${format} !== true && ${fType} === ${ruleType} && !${validData}`;
+                    ? (0, codegen_1$1._) `(${fDef}.async ? await ${format}(${data}) : ${format}(${data}))`
+                    : (0, codegen_1$1._) `${format}(${data})`;
+                const validData = (0, codegen_1$1._) `(typeof ${format} == "function" ? ${callFormat} : ${format}.test(${data}))`;
+                return (0, codegen_1$1._) `${format} && ${format} !== true && ${fType} === ${ruleType} && !${validData}`;
             }
         }
         function validateFormat() {
@@ -6662,13 +6963,13 @@ const def$1 = {
             }
             function getFormat(fmtDef) {
                 const code = fmtDef instanceof RegExp
-                    ? codegen_1$1.regexpCode(fmtDef)
+                    ? (0, codegen_1$1.regexpCode)(fmtDef)
                     : opts.code.formats
-                        ? codegen_1$1._ `${opts.code.formats}${codegen_1$1.getProperty(schema)}`
+                        ? (0, codegen_1$1._) `${opts.code.formats}${(0, codegen_1$1.getProperty)(schema)}`
                         : undefined;
                 const fmt = gen.scopeValue("formats", { key: schema, ref: fmtDef, code });
                 if (typeof fmtDef == "object" && !(fmtDef instanceof RegExp)) {
-                    return [fmtDef.type || "string", fmtDef.validate, codegen_1$1._ `${fmt}.validate`];
+                    return [fmtDef.type || "string", fmtDef.validate, (0, codegen_1$1._) `${fmt}.validate`];
                 }
                 return ["string", fmtDef, fmt];
             }
@@ -6676,25 +6977,25 @@ const def$1 = {
                 if (typeof formatDef == "object" && !(formatDef instanceof RegExp) && formatDef.async) {
                     if (!schemaEnv.$async)
                         throw new Error("async format in sync schema");
-                    return codegen_1$1._ `await ${fmtRef}(${data})`;
+                    return (0, codegen_1$1._) `await ${fmtRef}(${data})`;
                 }
-                return typeof format == "function" ? codegen_1$1._ `${fmtRef}(${data})` : codegen_1$1._ `${fmtRef}.test(${data})`;
+                return typeof format == "function" ? (0, codegen_1$1._) `${fmtRef}(${data})` : (0, codegen_1$1._) `${fmtRef}.test(${data})`;
             }
         }
     },
 };
-format$1.default = def$1;
+format$2.default = def$1;
 
-Object.defineProperty(format$2, "__esModule", { value: true });
-const format_1$1 = format$1;
-const format = [format_1$1.default];
-format$2.default = format;
+Object.defineProperty(format$3, "__esModule", { value: true });
+const format_1$1 = format$2;
+const format$1 = [format_1$1.default];
+format$3.default = format$1;
 
-var metadata = {};
+var metadata$1 = {};
 
-Object.defineProperty(metadata, "__esModule", { value: true });
-metadata.contentVocabulary = metadata.metadataVocabulary = void 0;
-metadata.metadataVocabulary = [
+Object.defineProperty(metadata$1, "__esModule", { value: true });
+metadata$1.contentVocabulary = metadata$1.metadataVocabulary = void 0;
+metadata$1.metadataVocabulary = [
     "title",
     "description",
     "default",
@@ -6703,27 +7004,33 @@ metadata.metadataVocabulary = [
     "writeOnly",
     "examples",
 ];
-metadata.contentVocabulary = [
+metadata$1.contentVocabulary = [
     "contentMediaType",
     "contentEncoding",
     "contentSchema",
 ];
 
-Object.defineProperty(draft7, "__esModule", { value: true });
-const core_1 = core$1;
-const validation_1 = validation$1;
-const applicator_1 = applicator;
-const format_1 = format$2;
-const metadata_1 = metadata;
-const draft7Vocabularies = [
+Object.defineProperty(draft2020, "__esModule", { value: true });
+const core_1 = core$2;
+const validation_1 = validation$2;
+const applicator_1 = applicator$1;
+const dynamic_1 = dynamic$1;
+const next_1 = next$1;
+const unevaluated_1 = unevaluated$2;
+const format_1 = format$3;
+const metadata_1 = metadata$1;
+const draft2020Vocabularies = [
+    dynamic_1.default,
     core_1.default,
     validation_1.default,
-    applicator_1.default(),
+    (0, applicator_1.default)(true),
     format_1.default,
     metadata_1.metadataVocabulary,
     metadata_1.contentVocabulary,
+    next_1.default,
+    unevaluated_1.default,
 ];
-draft7.default = draft7Vocabularies;
+draft2020.default = draft2020Vocabularies;
 
 var discriminator = {};
 
@@ -6746,7 +7053,7 @@ const error = {
     message: ({ params: { discrError, tagName } }) => discrError === types_1.DiscrError.Tag
         ? `tag "${tagName}" must be string`
         : `value of tag "${tagName}" must be in oneOf`,
-    params: ({ params: { discrError, tag, tagName } }) => codegen_1._ `{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`,
+    params: ({ params: { discrError, tag, tagName } }) => (0, codegen_1._) `{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`,
 };
 const def = {
     keyword: "discriminator",
@@ -6767,14 +7074,14 @@ const def = {
         if (!oneOf)
             throw new Error("discriminator: requires oneOf keyword");
         const valid = gen.let("valid", false);
-        const tag = gen.const("tag", codegen_1._ `${data}${codegen_1.getProperty(tagName)}`);
-        gen.if(codegen_1._ `typeof ${tag} == "string"`, () => validateMapping(), () => cxt.error(false, { discrError: types_1.DiscrError.Tag, tag, tagName }));
+        const tag = gen.const("tag", (0, codegen_1._) `${data}${(0, codegen_1.getProperty)(tagName)}`);
+        gen.if((0, codegen_1._) `typeof ${tag} == "string"`, () => validateMapping(), () => cxt.error(false, { discrError: types_1.DiscrError.Tag, tag, tagName }));
         cxt.ok(valid);
         function validateMapping() {
             const mapping = getMapping();
             gen.if(false);
             for (const tagValue in mapping) {
-                gen.elseIf(codegen_1._ `${tag} === ${tagValue}`);
+                gen.elseIf((0, codegen_1._) `${tag} === ${tagValue}`);
                 gen.assign(valid, applyTagSchema(mapping[tagValue]));
             }
             gen.else();
@@ -6831,30 +7138,504 @@ const def = {
 };
 discriminator.default = def;
 
-var $schema = "http://json-schema.org/draft-07/schema#";
-var $id = "http://json-schema.org/draft-07/schema#";
-var title$i = "Core schema meta-schema";
-var definitions$3 = {
+var jsonSchema202012 = {};
+
+var $schema$7 = "https://json-schema.org/draft/2020-12/schema";
+var $id$9 = "https://json-schema.org/draft/2020-12/schema";
+var $vocabulary$7 = {
+	"https://json-schema.org/draft/2020-12/vocab/core": true,
+	"https://json-schema.org/draft/2020-12/vocab/applicator": true,
+	"https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+	"https://json-schema.org/draft/2020-12/vocab/validation": true,
+	"https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+	"https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+	"https://json-schema.org/draft/2020-12/vocab/content": true
+};
+var $dynamicAnchor$7 = "meta";
+var title$p = "Core and Validation specifications meta-schema";
+var allOf = [
+	{
+		$ref: "meta/core"
+	},
+	{
+		$ref: "meta/applicator"
+	},
+	{
+		$ref: "meta/unevaluated"
+	},
+	{
+		$ref: "meta/validation"
+	},
+	{
+		$ref: "meta/meta-data"
+	},
+	{
+		$ref: "meta/format-annotation"
+	},
+	{
+		$ref: "meta/content"
+	}
+];
+var type$p = [
+	"object",
+	"boolean"
+];
+var $comment = "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.";
+var properties$o = {
+	definitions: {
+		$comment: "\"definitions\" has been replaced by \"$defs\".",
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		deprecated: true,
+		"default": {
+		}
+	},
+	dependencies: {
+		$comment: "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+		type: "object",
+		additionalProperties: {
+			anyOf: [
+				{
+					$dynamicRef: "#meta"
+				},
+				{
+					$ref: "meta/validation#/$defs/stringArray"
+				}
+			]
+		},
+		deprecated: true,
+		"default": {
+		}
+	},
+	$recursiveAnchor: {
+		$comment: "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+		$ref: "meta/core#/$defs/anchorString",
+		deprecated: true
+	},
+	$recursiveRef: {
+		$comment: "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+		$ref: "meta/core#/$defs/uriReferenceString",
+		deprecated: true
+	}
+};
+var require$$0 = {
+	$schema: $schema$7,
+	$id: $id$9,
+	$vocabulary: $vocabulary$7,
+	$dynamicAnchor: $dynamicAnchor$7,
+	title: title$p,
+	allOf: allOf,
+	type: type$p,
+	$comment: $comment,
+	properties: properties$o
+};
+
+var $schema$6 = "https://json-schema.org/draft/2020-12/schema";
+var $id$8 = "https://json-schema.org/draft/2020-12/meta/applicator";
+var $vocabulary$6 = {
+	"https://json-schema.org/draft/2020-12/vocab/applicator": true
+};
+var $dynamicAnchor$6 = "meta";
+var title$o = "Applicator vocabulary meta-schema";
+var type$o = [
+	"object",
+	"boolean"
+];
+var properties$n = {
+	prefixItems: {
+		$ref: "#/$defs/schemaArray"
+	},
+	items: {
+		$dynamicRef: "#meta"
+	},
+	contains: {
+		$dynamicRef: "#meta"
+	},
+	additionalProperties: {
+		$dynamicRef: "#meta"
+	},
+	properties: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		"default": {
+		}
+	},
+	patternProperties: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		propertyNames: {
+			format: "regex"
+		},
+		"default": {
+		}
+	},
+	dependentSchemas: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		},
+		"default": {
+		}
+	},
+	propertyNames: {
+		$dynamicRef: "#meta"
+	},
+	"if": {
+		$dynamicRef: "#meta"
+	},
+	then: {
+		$dynamicRef: "#meta"
+	},
+	"else": {
+		$dynamicRef: "#meta"
+	},
+	allOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	anyOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	oneOf: {
+		$ref: "#/$defs/schemaArray"
+	},
+	not: {
+		$dynamicRef: "#meta"
+	}
+};
+var $defs$2 = {
 	schemaArray: {
 		type: "array",
 		minItems: 1,
 		items: {
-			$ref: "#"
+			$dynamicRef: "#meta"
+		}
+	}
+};
+var require$$1 = {
+	$schema: $schema$6,
+	$id: $id$8,
+	$vocabulary: $vocabulary$6,
+	$dynamicAnchor: $dynamicAnchor$6,
+	title: title$o,
+	type: type$o,
+	properties: properties$n,
+	$defs: $defs$2
+};
+
+var $schema$5 = "https://json-schema.org/draft/2020-12/schema";
+var $id$7 = "https://json-schema.org/draft/2020-12/meta/unevaluated";
+var $vocabulary$5 = {
+	"https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+};
+var $dynamicAnchor$5 = "meta";
+var title$n = "Unevaluated applicator vocabulary meta-schema";
+var type$n = [
+	"object",
+	"boolean"
+];
+var properties$m = {
+	unevaluatedItems: {
+		$dynamicRef: "#meta"
+	},
+	unevaluatedProperties: {
+		$dynamicRef: "#meta"
+	}
+};
+var require$$2 = {
+	$schema: $schema$5,
+	$id: $id$7,
+	$vocabulary: $vocabulary$5,
+	$dynamicAnchor: $dynamicAnchor$5,
+	title: title$n,
+	type: type$n,
+	properties: properties$m
+};
+
+var $schema$4 = "https://json-schema.org/draft/2020-12/schema";
+var $id$6 = "https://json-schema.org/draft/2020-12/meta/content";
+var $vocabulary$4 = {
+	"https://json-schema.org/draft/2020-12/vocab/content": true
+};
+var $dynamicAnchor$4 = "meta";
+var title$m = "Content vocabulary meta-schema";
+var type$m = [
+	"object",
+	"boolean"
+];
+var properties$l = {
+	contentEncoding: {
+		type: "string"
+	},
+	contentMediaType: {
+		type: "string"
+	},
+	contentSchema: {
+		$dynamicRef: "#meta"
+	}
+};
+var require$$3 = {
+	$schema: $schema$4,
+	$id: $id$6,
+	$vocabulary: $vocabulary$4,
+	$dynamicAnchor: $dynamicAnchor$4,
+	title: title$m,
+	type: type$m,
+	properties: properties$l
+};
+
+var $schema$3 = "https://json-schema.org/draft/2020-12/schema";
+var $id$5 = "https://json-schema.org/draft/2020-12/meta/core";
+var $vocabulary$3 = {
+	"https://json-schema.org/draft/2020-12/vocab/core": true
+};
+var $dynamicAnchor$3 = "meta";
+var title$l = "Core vocabulary meta-schema";
+var type$l = [
+	"object",
+	"boolean"
+];
+var properties$k = {
+	$id: {
+		$ref: "#/$defs/uriReferenceString",
+		$comment: "Non-empty fragments not allowed.",
+		pattern: "^[^#]*#?$"
+	},
+	$schema: {
+		$ref: "#/$defs/uriString"
+	},
+	$ref: {
+		$ref: "#/$defs/uriReferenceString"
+	},
+	$anchor: {
+		$ref: "#/$defs/anchorString"
+	},
+	$dynamicRef: {
+		$ref: "#/$defs/uriReferenceString"
+	},
+	$dynamicAnchor: {
+		$ref: "#/$defs/anchorString"
+	},
+	$vocabulary: {
+		type: "object",
+		propertyNames: {
+			$ref: "#/$defs/uriString"
+		},
+		additionalProperties: {
+			type: "boolean"
 		}
 	},
+	$comment: {
+		type: "string"
+	},
+	$defs: {
+		type: "object",
+		additionalProperties: {
+			$dynamicRef: "#meta"
+		}
+	}
+};
+var $defs$1 = {
+	anchorString: {
+		type: "string",
+		pattern: "^[A-Za-z_][-A-Za-z0-9._]*$"
+	},
+	uriString: {
+		type: "string",
+		format: "uri"
+	},
+	uriReferenceString: {
+		type: "string",
+		format: "uri-reference"
+	}
+};
+var require$$4 = {
+	$schema: $schema$3,
+	$id: $id$5,
+	$vocabulary: $vocabulary$3,
+	$dynamicAnchor: $dynamicAnchor$3,
+	title: title$l,
+	type: type$l,
+	properties: properties$k,
+	$defs: $defs$1
+};
+
+var $schema$2 = "https://json-schema.org/draft/2020-12/schema";
+var $id$4 = "https://json-schema.org/draft/2020-12/meta/format-annotation";
+var $vocabulary$2 = {
+	"https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+};
+var $dynamicAnchor$2 = "meta";
+var title$k = "Format vocabulary meta-schema for annotation results";
+var type$k = [
+	"object",
+	"boolean"
+];
+var properties$j = {
+	format: {
+		type: "string"
+	}
+};
+var require$$5 = {
+	$schema: $schema$2,
+	$id: $id$4,
+	$vocabulary: $vocabulary$2,
+	$dynamicAnchor: $dynamicAnchor$2,
+	title: title$k,
+	type: type$k,
+	properties: properties$j
+};
+
+var $schema$1 = "https://json-schema.org/draft/2020-12/schema";
+var $id$3 = "https://json-schema.org/draft/2020-12/meta/meta-data";
+var $vocabulary$1 = {
+	"https://json-schema.org/draft/2020-12/vocab/meta-data": true
+};
+var $dynamicAnchor$1 = "meta";
+var title$j = "Meta-data vocabulary meta-schema";
+var type$j = [
+	"object",
+	"boolean"
+];
+var properties$i = {
+	title: {
+		type: "string"
+	},
+	description: {
+		type: "string"
+	},
+	"default": true,
+	deprecated: {
+		type: "boolean",
+		"default": false
+	},
+	readOnly: {
+		type: "boolean",
+		"default": false
+	},
+	writeOnly: {
+		type: "boolean",
+		"default": false
+	},
+	examples: {
+		type: "array",
+		items: true
+	}
+};
+var require$$6 = {
+	$schema: $schema$1,
+	$id: $id$3,
+	$vocabulary: $vocabulary$1,
+	$dynamicAnchor: $dynamicAnchor$1,
+	title: title$j,
+	type: type$j,
+	properties: properties$i
+};
+
+var $schema = "https://json-schema.org/draft/2020-12/schema";
+var $id$2 = "https://json-schema.org/draft/2020-12/meta/validation";
+var $vocabulary = {
+	"https://json-schema.org/draft/2020-12/vocab/validation": true
+};
+var $dynamicAnchor = "meta";
+var title$i = "Validation vocabulary meta-schema";
+var type$i = [
+	"object",
+	"boolean"
+];
+var properties$h = {
+	type: {
+		anyOf: [
+			{
+				$ref: "#/$defs/simpleTypes"
+			},
+			{
+				type: "array",
+				items: {
+					$ref: "#/$defs/simpleTypes"
+				},
+				minItems: 1,
+				uniqueItems: true
+			}
+		]
+	},
+	"const": true,
+	"enum": {
+		type: "array",
+		items: true
+	},
+	multipleOf: {
+		type: "number",
+		exclusiveMinimum: 0
+	},
+	maximum: {
+		type: "number"
+	},
+	exclusiveMaximum: {
+		type: "number"
+	},
+	minimum: {
+		type: "number"
+	},
+	exclusiveMinimum: {
+		type: "number"
+	},
+	maxLength: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minLength: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	pattern: {
+		type: "string",
+		format: "regex"
+	},
+	maxItems: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minItems: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	uniqueItems: {
+		type: "boolean",
+		"default": false
+	},
+	maxContains: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minContains: {
+		$ref: "#/$defs/nonNegativeInteger",
+		"default": 1
+	},
+	maxProperties: {
+		$ref: "#/$defs/nonNegativeInteger"
+	},
+	minProperties: {
+		$ref: "#/$defs/nonNegativeIntegerDefault0"
+	},
+	required: {
+		$ref: "#/$defs/stringArray"
+	},
+	dependentRequired: {
+		type: "object",
+		additionalProperties: {
+			$ref: "#/$defs/stringArray"
+		}
+	}
+};
+var $defs = {
 	nonNegativeInteger: {
 		type: "integer",
 		minimum: 0
 	},
 	nonNegativeIntegerDefault0: {
-		allOf: [
-			{
-				$ref: "#/definitions/nonNegativeInteger"
-			},
-			{
-				"default": 0
-			}
-		]
+		$ref: "#/$defs/nonNegativeInteger",
+		"default": 0
 	},
 	simpleTypes: {
 		"enum": [
@@ -6877,236 +7658,74 @@ var definitions$3 = {
 		]
 	}
 };
-var type$i = [
-	"object",
-	"boolean"
-];
-var properties$h = {
-	$id: {
-		type: "string",
-		format: "uri-reference"
-	},
-	$schema: {
-		type: "string",
-		format: "uri"
-	},
-	$ref: {
-		type: "string",
-		format: "uri-reference"
-	},
-	$comment: {
-		type: "string"
-	},
-	title: {
-		type: "string"
-	},
-	description: {
-		type: "string"
-	},
-	"default": true,
-	readOnly: {
-		type: "boolean",
-		"default": false
-	},
-	examples: {
-		type: "array",
-		items: true
-	},
-	multipleOf: {
-		type: "number",
-		exclusiveMinimum: 0
-	},
-	maximum: {
-		type: "number"
-	},
-	exclusiveMaximum: {
-		type: "number"
-	},
-	minimum: {
-		type: "number"
-	},
-	exclusiveMinimum: {
-		type: "number"
-	},
-	maxLength: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minLength: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	pattern: {
-		type: "string",
-		format: "regex"
-	},
-	additionalItems: {
-		$ref: "#"
-	},
-	items: {
-		anyOf: [
-			{
-				$ref: "#"
-			},
-			{
-				$ref: "#/definitions/schemaArray"
-			}
-		],
-		"default": true
-	},
-	maxItems: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minItems: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	uniqueItems: {
-		type: "boolean",
-		"default": false
-	},
-	contains: {
-		$ref: "#"
-	},
-	maxProperties: {
-		$ref: "#/definitions/nonNegativeInteger"
-	},
-	minProperties: {
-		$ref: "#/definitions/nonNegativeIntegerDefault0"
-	},
-	required: {
-		$ref: "#/definitions/stringArray"
-	},
-	additionalProperties: {
-		$ref: "#"
-	},
-	definitions: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		"default": {
-		}
-	},
-	properties: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		"default": {
-		}
-	},
-	patternProperties: {
-		type: "object",
-		additionalProperties: {
-			$ref: "#"
-		},
-		propertyNames: {
-			format: "regex"
-		},
-		"default": {
-		}
-	},
-	dependencies: {
-		type: "object",
-		additionalProperties: {
-			anyOf: [
-				{
-					$ref: "#"
-				},
-				{
-					$ref: "#/definitions/stringArray"
-				}
-			]
-		}
-	},
-	propertyNames: {
-		$ref: "#"
-	},
-	"const": true,
-	"enum": {
-		type: "array",
-		items: true,
-		minItems: 1,
-		uniqueItems: true
-	},
-	type: {
-		anyOf: [
-			{
-				$ref: "#/definitions/simpleTypes"
-			},
-			{
-				type: "array",
-				items: {
-					$ref: "#/definitions/simpleTypes"
-				},
-				minItems: 1,
-				uniqueItems: true
-			}
-		]
-	},
-	format: {
-		type: "string"
-	},
-	contentMediaType: {
-		type: "string"
-	},
-	contentEncoding: {
-		type: "string"
-	},
-	"if": {
-		$ref: "#"
-	},
-	then: {
-		$ref: "#"
-	},
-	"else": {
-		$ref: "#"
-	},
-	allOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	anyOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	oneOf: {
-		$ref: "#/definitions/schemaArray"
-	},
-	not: {
-		$ref: "#"
-	}
-};
-var require$$3 = {
+var require$$7 = {
 	$schema: $schema,
-	$id: $id,
+	$id: $id$2,
+	$vocabulary: $vocabulary,
+	$dynamicAnchor: $dynamicAnchor,
 	title: title$i,
-	definitions: definitions$3,
 	type: type$i,
 	properties: properties$h,
-	"default": true
+	$defs: $defs
 };
+
+Object.defineProperty(jsonSchema202012, "__esModule", { value: true });
+const metaSchema = require$$0;
+const applicator = require$$1;
+const unevaluated = require$$2;
+const content = require$$3;
+const core = require$$4;
+const format = require$$5;
+const metadata = require$$6;
+const validation = require$$7;
+const META_SUPPORT_DATA = ["/properties"];
+function addMetaSchema2020($data) {
+    [
+        metaSchema,
+        applicator,
+        unevaluated,
+        content,
+        core,
+        with$data(this, format),
+        metadata,
+        with$data(this, validation),
+    ].forEach((sch) => this.addMetaSchema(sch, undefined, false));
+    return this;
+    function with$data(ajv, sch) {
+        return $data ? ajv.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
+    }
+}
+jsonSchema202012.default = addMetaSchema2020;
 
 (function (module, exports) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
-const core_1 = core$2;
-const draft7_1 = draft7;
+const core_1 = core$3;
+const draft2020_1 = draft2020;
 const discriminator_1 = discriminator;
-const draft7MetaSchema = require$$3;
-const META_SUPPORT_DATA = ["/properties"];
-const META_SCHEMA_ID = "http://json-schema.org/draft-07/schema";
-class Ajv extends core_1.default {
+const json_schema_2020_12_1 = jsonSchema202012;
+const META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema";
+class Ajv2020 extends core_1.default {
+    constructor(opts = {}) {
+        super({
+            ...opts,
+            dynamicRef: true,
+            next: true,
+            unevaluated: true,
+        });
+    }
     _addVocabularies() {
         super._addVocabularies();
-        draft7_1.default.forEach((v) => this.addVocabulary(v));
+        draft2020_1.default.forEach((v) => this.addVocabulary(v));
         if (this.opts.discriminator)
             this.addKeyword(discriminator_1.default);
     }
     _addDefaultMetaSchema() {
         super._addDefaultMetaSchema();
-        if (!this.opts.meta)
+        const { $data, meta } = this.opts;
+        if (!meta)
             return;
-        const metaSchema = this.opts.$data
-            ? this.$dataMetaSchema(draft7MetaSchema, META_SUPPORT_DATA)
-            : draft7MetaSchema;
-        this.addMetaSchema(metaSchema, META_SCHEMA_ID, false);
+        json_schema_2020_12_1.default.call(this, $data);
         this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
     }
     defaultMeta() {
@@ -7114,9 +7733,9 @@ class Ajv extends core_1.default {
             super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : undefined));
     }
 }
-module.exports = exports = Ajv;
+module.exports = exports = Ajv2020;
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = Ajv;
+exports.default = Ajv2020;
 var validate_1 = validate;
 Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function () { return validate_1.KeywordCxt; } });
 var codegen_1 = codegen;
@@ -7127,12 +7746,16 @@ Object.defineProperty(exports, "nil", { enumerable: true, get: function () { ret
 Object.defineProperty(exports, "Name", { enumerable: true, get: function () { return codegen_1.Name; } });
 Object.defineProperty(exports, "CodeGen", { enumerable: true, get: function () { return codegen_1.CodeGen; } });
 
-}(ajv, ajv.exports));
+}(_2020, _2020.exports));
 
-var Ajv = /*@__PURE__*/getDefaultExportFromCjs(ajv.exports);
+var Ajv = /*@__PURE__*/getDefaultExportFromCjs(_2020.exports);
 
 const getValidation = (schema, example) => {
-    const ajv = new Ajv();
+    const ajv = new Ajv({
+        strict: "log",
+        verbose: true,
+        strictSchema: "log"
+    });
     const validate = ajv.compile(schema);
     return validate(example);
 };
@@ -7143,9 +7766,16 @@ const isValidSchema = (schema, example) => {
     }
     return true;
 };
+const getValidationWithDependencies = (schema, dependencies, example) => {
+    // When dealing with multiple schemas, you need to make sure they are all loaded before trying to validate
+    // Currently, DeviceShadow depends on Config being loaded, so you would need to call addSchema with Config
+    const ajv = new Ajv();
+    const validate = ajv.addSchema(dependencies).compile(schema);
+    return validate(example);
+};
 
 var title$h = "Air Quality";
-var description$j = "Set configuration values for the air quality module";
+var description$k = "Set configuration values for the air quality module";
 var type$h = "object";
 var properties$g = {
 	appId: {
@@ -7182,7 +7812,7 @@ var required$h = [
 var additionalProperties$g = false;
 var air_quality$1 = {
 	title: title$h,
-	description: description$j,
+	description: description$k,
 	type: type$h,
 	properties: properties$g,
 	required: required$h,
@@ -7192,7 +7822,7 @@ var air_quality$1 = {
 var AirQualityC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$h,
-	description: description$j,
+	description: description$k,
 	type: type$h,
 	properties: properties$g,
 	required: required$h,
@@ -7201,7 +7831,7 @@ var AirQualityC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$g = "Device";
-var description$i = "Request from the cloud for the device to gracefully disconnect";
+var description$j = "Request from the cloud for the device to gracefully disconnect";
 var type$g = "object";
 var properties$f = {
 	appId: {
@@ -7220,7 +7850,7 @@ var required$g = [
 var additionalProperties$f = false;
 var device$1 = {
 	title: title$g,
-	description: description$i,
+	description: description$j,
 	type: type$g,
 	properties: properties$f,
 	required: required$g,
@@ -7230,7 +7860,7 @@ var device$1 = {
 var DeviceC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$g,
-	description: description$i,
+	description: description$j,
 	type: type$g,
 	properties: properties$f,
 	required: required$g,
@@ -7239,7 +7869,7 @@ var DeviceC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$f = "Environmental Settings";
-var description$h = "The environmental sensors module settings";
+var description$i = "The environmental sensors module settings";
 var type$f = "object";
 var properties$e = {
 	appId: {
@@ -7269,7 +7899,7 @@ var required$f = [
 var additionalProperties$e = false;
 var env = {
 	title: title$f,
-	description: description$h,
+	description: description$i,
 	type: type$f,
 	properties: properties$e,
 	required: required$f,
@@ -7279,7 +7909,7 @@ var env = {
 var EnvC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$f,
-	description: description$h,
+	description: description$i,
 	type: type$f,
 	properties: properties$e,
 	required: required$f,
@@ -7288,7 +7918,7 @@ var EnvC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$e = "GPS Configuration";
-var description$g = "Sets configuration values for the GPS module";
+var description$h = "Sets configuration values for the GPS module";
 var type$e = "object";
 var properties$d = {
 	appId: {
@@ -7321,7 +7951,7 @@ var required$e = [
 ];
 var gps$1 = {
 	title: title$e,
-	description: description$g,
+	description: description$h,
 	type: type$e,
 	properties: properties$d,
 	additionalProperties: additionalProperties$d,
@@ -7331,7 +7961,7 @@ var gps$1 = {
 var GPSC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$e,
-	description: description$g,
+	description: description$h,
 	type: type$e,
 	properties: properties$d,
 	additionalProperties: additionalProperties$d,
@@ -7340,7 +7970,7 @@ var GPSC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$d = "LED";
-var description$f = "Sets configuration of the device's LED";
+var description$g = "Sets configuration of the device's LED";
 var type$d = "object";
 var properties$c = {
 	appId: {
@@ -7371,7 +8001,7 @@ var required$d = [
 var additionalProperties$c = false;
 var led = {
 	title: title$d,
-	description: description$f,
+	description: description$g,
 	type: type$d,
 	properties: properties$c,
 	required: required$d,
@@ -7381,7 +8011,7 @@ var led = {
 var LEDC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$d,
-	description: description$f,
+	description: description$g,
 	type: type$d,
 	properties: properties$c,
 	required: required$d,
@@ -7390,7 +8020,7 @@ var LEDC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$c = "Light";
-var description$e = "Sets configuration values for the light sensor module";
+var description$f = "Sets configuration values for the light sensor module";
 var type$c = "object";
 var properties$b = {
 	appId: {
@@ -7424,7 +8054,7 @@ var required$c = [
 ];
 var light$1 = {
 	title: title$c,
-	description: description$e,
+	description: description$f,
 	type: type$c,
 	properties: properties$b,
 	additionalProperties: additionalProperties$b,
@@ -7434,7 +8064,7 @@ var light$1 = {
 var LightC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$c,
-	description: description$e,
+	description: description$f,
 	type: type$c,
 	properties: properties$b,
 	additionalProperties: additionalProperties$b,
@@ -7443,7 +8073,7 @@ var LightC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$b = "Modem";
-var description$d = "IP device modem information";
+var description$e = "IP device modem information";
 var type$b = "object";
 var additionalProperties$a = false;
 var properties$a = {
@@ -7470,7 +8100,7 @@ var required$b = [
 ];
 var modem = {
 	title: title$b,
-	description: description$d,
+	description: description$e,
 	type: type$b,
 	additionalProperties: additionalProperties$a,
 	properties: properties$a,
@@ -7480,7 +8110,7 @@ var modem = {
 var ModemC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$b,
-	description: description$d,
+	description: description$e,
 	type: type$b,
 	additionalProperties: additionalProperties$a,
 	properties: properties$a,
@@ -7489,7 +8119,7 @@ var ModemC2D = /*#__PURE__*/Object.freeze({
 });
 
 var title$a = "Temperature";
-var description$c = "Sets configuration values for the temperature module";
+var description$d = "Sets configuration values for the temperature module";
 var type$a = "object";
 var properties$9 = {
 	appId: {
@@ -7526,7 +8156,7 @@ var required$a = [
 ];
 var temp$1 = {
 	title: title$a,
-	description: description$c,
+	description: description$d,
 	type: type$a,
 	properties: properties$9,
 	additionalProperties: additionalProperties$9,
@@ -7536,7 +8166,7 @@ var temp$1 = {
 var TemperatureC2D = /*#__PURE__*/Object.freeze({
 	__proto__: null,
 	title: title$a,
-	description: description$c,
+	description: description$d,
 	type: type$a,
 	properties: properties$9,
 	additionalProperties: additionalProperties$9,
@@ -7544,9 +8174,9 @@ var TemperatureC2D = /*#__PURE__*/Object.freeze({
 	'default': temp$1
 });
 
-var description$b = "The desired and reported state of a BLE Gateway device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
-var $ref$1 = "#/definitions/DeviceShadowIP";
-var definitions$2 = {
+var description$c = "The desired and reported state of a BLE Gateway device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
+var $ref$2 = "#/definitions/DeviceShadowIP";
+var definitions$3 = {
 	DeviceShadowIP: {
 		type: "object",
 		additionalProperties: false,
@@ -7679,22 +8309,23 @@ var definitions$2 = {
 	}
 };
 var gatewayShadow = {
-	description: description$b,
-	$ref: $ref$1,
-	definitions: definitions$2
+	description: description$c,
+	$ref: $ref$2,
+	definitions: definitions$3
 };
 
 var Gateway = /*#__PURE__*/Object.freeze({
 	__proto__: null,
-	description: description$b,
-	$ref: $ref$1,
-	definitions: definitions$2,
+	description: description$c,
+	$ref: $ref$2,
+	definitions: definitions$3,
 	'default': gatewayShadow
 });
 
-var description$a = "The desired and reported state of an IP device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
-var $ref = "#/definitions/DeviceShadowIP";
-var definitions$1 = {
+var $id$1 = "/ipShadow.json";
+var description$b = "The desired and reported state of an IP device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).";
+var $ref$1 = "#/definitions/DeviceShadowIP";
+var definitions$2 = {
 	DeviceShadowIP: {
 		type: "object",
 		additionalProperties: false,
@@ -7724,7 +8355,7 @@ var definitions$1 = {
 				type: "string"
 			},
 			config: {
-				$ref: "#/definitions/Config"
+				$ref: "config.json#/definitions/Config"
 			}
 		},
 		required: [
@@ -7751,7 +8382,7 @@ var definitions$1 = {
 				$ref: "#/definitions/Device"
 			},
 			config: {
-				$ref: "#/definitions/Config"
+				$ref: "config.json#/definitions/Config"
 			}
 		},
 		required: [
@@ -7805,29 +8436,6 @@ var definitions$1 = {
 			"d2c"
 		],
 		title: "Topics"
-	},
-	Config: {
-		type: "object",
-		description: "Client set device configuration.",
-		properties: {
-			GPS: {
-				$ref: "#/definitions/Gps"
-			}
-		},
-		title: "Config"
-	},
-	Gps: {
-		type: "object",
-		description: "Enable GPS",
-		properties: {
-			enable: {
-				type: "boolean"
-			}
-		},
-		required: [
-			"enable"
-		],
-		title: "Gps"
 	},
 	Connection: {
 		type: "object",
@@ -8031,17 +8639,63 @@ var definitions$1 = {
 	}
 };
 var ipShadow = {
+	$id: $id$1,
+	description: description$b,
+	$ref: $ref$1,
+	definitions: definitions$2
+};
+
+var IP = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	$id: $id$1,
+	description: description$b,
+	$ref: $ref$1,
+	definitions: definitions$2,
+	'default': ipShadow
+});
+
+var $id = "/config.json";
+var description$a = "The reported config within the AWS IoT Shadow.";
+var $ref = "#/definitions/Config";
+var definitions$1 = {
+	Config: {
+		type: "object",
+		description: "Client set device configuration.",
+		properties: {
+			GPS: {
+				$ref: "#/definitions/Gps"
+			}
+		},
+		title: "Config"
+	},
+	Gps: {
+		type: "object",
+		description: "Enable GPS",
+		properties: {
+			enable: {
+				type: "boolean"
+			}
+		},
+		required: [
+			"enable"
+		],
+		title: "Gps"
+	}
+};
+var config = {
+	$id: $id,
 	description: description$a,
 	$ref: $ref,
 	definitions: definitions$1
 };
 
-var IP = /*#__PURE__*/Object.freeze({
+var Config = /*#__PURE__*/Object.freeze({
 	__proto__: null,
+	$id: $id,
 	description: description$a,
 	$ref: $ref,
 	definitions: definitions$1,
-	'default': ipShadow
+	'default': config
 });
 
 var title$9 = "Air pressure";
@@ -8058,7 +8712,7 @@ var properties$8 = {
 	},
 	data: {
 		type: "string",
-		pattern: "^([0-9]|[1-9][0-9]+)\\.[0-9]+$"
+		pattern: "^([0-9]|[1-9][0-9]+)(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8502,7 +9156,7 @@ var oneOf = [
 			data: {
 				type: "string",
 				description: "NEMA string",
-				pattern: "^\\$(GPGGA|GPGLL|GPGSA|GPGSV|GPRMC|GPVTG)(,[0-9A-Z\\*\\.]*)+$"
+				pattern: "^\\$(GPGGA|GPGLL|GPGSA|GPGSV|GPRMC|GPVTG)(,[0-9A-Z\\*\\.]*)+\n?$"
 			},
 			ts: {
 				type: "number",
@@ -8553,7 +9207,7 @@ var properties$3 = {
 	data: {
 		type: "string",
 		description: "Relative humidity percentage",
-		pattern: "^(([0-9]|[1-9][0-9])\\.[0-9])|100.0$"
+		pattern: "^(([0-9]|[1-9][0-9])(\\.[0-9])?)|100\\.0|100$"
 	},
 	ts: {
 		type: "number",
@@ -8657,7 +9311,7 @@ var properties$1 = {
 	data: {
 		type: "string",
 		description: "RSRP dBm string",
-		pattern: "^-[0-9]+.[0-9]+$"
+		pattern: "^-[0-9]+(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8711,7 +9365,7 @@ var properties = {
 	},
 	data: {
 		type: "string",
-		pattern: "^-?([0-9]|[1-9][0-9]+)\\.[0-9]+$"
+		pattern: "^-?([0-9]|[1-9][0-9]+)(\\.[0-9]+)?$"
 	},
 	ts: {
 		type: "number",
@@ -8761,6 +9415,7 @@ const CloudToGateway = {};
 const DeviceShadow = {
     Gateway,
     IP,
+    Config,
 };
 const DeviceToCloud = {
     AirPress: AirPressD2C,
@@ -8775,4 +9430,4 @@ const DeviceToCloud = {
     Temperature: TemperatureD2C,
 };
 
-export { CloudToDevice, CloudToGateway, DeviceShadow, DeviceToCloud, getValidation, isValidSchema };
+export { CloudToDevice, CloudToGateway, DeviceShadow, DeviceToCloud, getValidation, getValidationWithDependencies, isValidSchema };

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
-export { isValidSchema, getValidation } from './utilities';
+export { isValidSchema, getValidation, getValidationWithDependencies } from './utilities';
 export * from './schemas';

--- a/schemas.ts
+++ b/schemas.ts
@@ -9,6 +9,7 @@ import * as  TemperatureC2D from './schemas/cloudToDevice/temp/temp.json';
 
 import * as  Gateway from './schemas/deviceShadow/gatewayShadow/gatewayShadow.json';
 import * as  IP from './schemas/deviceShadow/ipShadow/ipShadow.json';
+import * as  Config from './schemas/deviceShadow/ipShadow/config.json';
 
 import * as  AirPressD2C from './schemas/deviceToCloud/air_press/air_press.json';
 import * as  AirQualityD2C from './schemas/deviceToCloud/air_quality/air_quality.json';
@@ -38,6 +39,7 @@ const CloudToGateway = {
 const DeviceShadow = {
     Gateway,
     IP,
+    Config,
 };
 
 const DeviceToCloud = {

--- a/schemas/deviceShadow/ipShadow/config.json
+++ b/schemas/deviceShadow/ipShadow/config.json
@@ -1,0 +1,30 @@
+{
+    "$id": "/config.json",
+    "description": "The reported config within the AWS IoT Shadow.",
+    "$ref": "#/definitions/Config",
+    "definitions": {
+        "Config": {
+            "type": "object",
+            "description": "Client set device configuration.",
+            "properties": {
+                "GPS": {
+                    "$ref": "#/definitions/Gps"
+                }
+            },
+            "title": "Config"
+        },
+        "Gps": {
+            "type": "object",
+            "description": "Enable GPS",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enable"
+            ],
+            "title": "Gps"
+        }
+    }
+}

--- a/schemas/deviceShadow/ipShadow/ipShadow.json
+++ b/schemas/deviceShadow/ipShadow/ipShadow.json
@@ -1,4 +1,5 @@
 {
+    "$id": "/ipShadow.json",
     "description": "The desired and reported state of an IP device using AWS IoT Shadow (https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html).",
     "$ref": "#/definitions/DeviceShadowIP",
     "definitions": {
@@ -31,7 +32,7 @@
                     "type": "string"
                 },
                 "config": {
-                    "$ref": "#/definitions/Config"
+                    "$ref": "config.json#/definitions/Config"
                 }
             },
             "required": [
@@ -58,7 +59,7 @@
                     "$ref": "#/definitions/Device"
                 },
                 "config": {
-                    "$ref": "#/definitions/Config"
+                    "$ref": "config.json#/definitions/Config"
                 }
             },
             "required": [
@@ -109,29 +110,6 @@
                 "d2c"
             ],
             "title": "Topics"
-        },
-        "Config": {
-            "type": "object",
-            "description": "Client set device configuration.",
-            "properties": {
-                "GPS": {
-                    "$ref": "#/definitions/Gps"
-                }
-            },
-            "title": "Config"
-        },
-        "Gps": {
-            "type": "object",
-            "description": "Enable GPS",
-            "properties": {
-                "enable": {
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enable"
-            ],
-            "title": "Gps"
         },
         "Connection": {
             "type": "object",

--- a/utilities.ts
+++ b/utilities.ts
@@ -1,9 +1,6 @@
 import Ajv, { Schema } from 'ajv/dist/2020';
 
 
-
-
-
 export const getValidation = (schema: Schema, example: Schema) => {
     const ajv = new Ajv({
         strict: "log",
@@ -23,4 +20,12 @@ export const isValidSchema = (schema: Schema, example: Schema) => {
     }
 
     return true;
+};
+
+export const getValidationWithDependencies = (schema: Schema, dependencies: Schema, example: Schema) => {
+    // When dealing with multiple schemas, you need to make sure they are all loaded before trying to validate
+    // Currently, DeviceShadow depends on Config being loaded, so you would need to call addSchema with Config
+    const ajv = new Ajv();
+    const validate = ajv.addSchema(dependencies).compile(schema);
+    return validate(example);
 };

--- a/utilities.ts
+++ b/utilities.ts
@@ -22,7 +22,7 @@ export const isValidSchema = (schema: Schema, example: Schema) => {
     return true;
 };
 
-export const getValidationWithDependencies = (schema: Schema, dependencies: Schema, example: Schema) => {
+export const getValidationWithDependencies = (schema: Schema, dependencies: Schema[], example: Schema) => {
     // When dealing with multiple schemas, you need to make sure they are all loaded before trying to validate
     // Currently, DeviceShadow depends on Config being loaded, so you would need to call addSchema with Config
     const ajv = new Ajv();


### PR DESCRIPTION
When working on building out a device configuration card, I needed to verify that the config section was correct according to this schema. In order to make that schema more accessible, I pulled it out into its own and now reference that within the deviceShadow.json.

- I created getValidationWithDependencies in the scenario where someone wants to verify against the entire device shadow. You will need to pass in the config schema to this to ensure that ajv knows about both of them.