### PR TITLE
fix: AJV should be in dependencies since it's a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/nRFCloud/application-protocols#readme",
   "dependencies": {
+    "ajv": "^8.8.1",
     "tcomb": "^3.2.29"
   },
   "devDependencies": {
@@ -44,7 +45,6 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.0.0",
-    "ajv": "^8.8.1",
     "glob": "^7.1.7",
     "husky": "^7.0.0",
     "jest": "^27.0.6",


### PR DESCRIPTION
### Problem

On the front end, application-protocols throws a Typescript error because it can't find AJV. Note that it only affects type checking.

### Solution

That's because AJV was listed as a dev dependency rather than a dependency. Since AJV is needed during runtime, it should be listed as a dependency.

### Testing

To see the error:
1. Check out [my type-checking branch](https://github.com/nRFCloud/nrfcloud-web-frontend/tree/kerr/add-type-checking) on the frontend
2. Run `npm run type-check`
3. Note that there's an error with application-protocols

To see the fix:
1. Check out this branch on application-protocols
2. Modify the Frontend's package.json entry for application-protocols to point to your local copy (something like `"@nrfcloud/application-protocols": "file:../application-protocols",` would work)
3. `npm i`
4. `npm run type-check`
5. See that the application-protocols error is gone

### Front End Changes Required

This fixes an issue on the Front end and doesn't require any changes there (except for updating the package.json with the new commit hash, but that's a different problem)

### System Impact

It shouldn't affect anything as this is more housekeeping than anything

### Jira Tickets

No Jira, only Zool.

### Release Notes

None
