### PR TITLE
docs: added link to mqtt api topic guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Devices that send messages to nRFCloud can optionally have data displayed on car
 **data**: Raw data from the application. See below under cloudToDevice and deviceToCloud for details. 
 
 **time | ts**: Timestamp parameter given by the device when the sample was taken (see [caveats](#caveats)).  
+## MQTT Topics
+To learn more about the topics on which these messages are broadcasted, check out our [MQTT API Guide](https://docs.nrfcloud.com/Reference/Interacting/MQTT#message-and-location-services-topics).
+
 ## Supported Schemas
 
 The schemas are divided into three folders:

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Devices that send messages to nRFCloud can optionally have data displayed on car
 **data**: Raw data from the application. See below under cloudToDevice and deviceToCloud for details. 
 
 **time | ts**: Timestamp parameter given by the device when the sample was taken (see [caveats](#caveats)).  
-## MQTT Topics
-To learn more about the topics on which these messages are broadcasted, check out our [MQTT API Guide](https://docs.nrfcloud.com/Reference/Interacting/MQTT#message-and-location-services-topics).
+## Message Topics
+To learn more about the topics on which these messages are broadcast, check out our [MQTT API Guide](https://docs.nrfcloud.com/Reference/Interacting/MQTT#message-and-location-services-topics).
 
 ## Supported Schemas
 


### PR DESCRIPTION
### Problem
We do not mention anything about MQTT topics and now since location services broadcast on their own topics, the assumption that everything uses c2d topic is not safe.

### Solution
Add link to MQTT API Topics Guide in the README

### Testing
Look at the README "Message Topics" section.

### Front End Changes Required
NONE

### System Impact
NONE

### Jira Tickets
[IRIS-4224](https://projecttools.nordicsemi.no/jira/browse/IRIS-4224)

### Release Notes
Updated the README to include link to MQTT API Topics Guide for location service topics