### PR TITLE
make data required

### DIFF
--- a/schemas/cloudToDevice/cell_position/cell-position.json
+++ b/schemas/cloudToDevice/cell_position/cell-position.json
@@ -36,8 +36,7 @@
     "additionalProperties":false,
     "required":[
        "appId",
-       "messageType",
-       "data"
+       "messageType"
     ],
     "definitions": {
       "Lat":{

--- a/schemas/cloudToDevice/cell_position/cell-position.json
+++ b/schemas/cloudToDevice/cell_position/cell-position.json
@@ -36,7 +36,8 @@
     "additionalProperties":false,
     "required":[
        "appId",
-       "messageType"
+       "messageType",
+       "data"
     ],
     "definitions": {
       "Lat":{

--- a/schemas/cloudToDevice/gps/gps.json
+++ b/schemas/cloudToDevice/gps/gps.json
@@ -29,6 +29,7 @@
     "additionalProperties":false,
     "required":[
        "appId",
-       "messageType"
+       "messageType",
+       "data"
     ]
  }

--- a/schemas/cloudToDevice/temp/temp.json
+++ b/schemas/cloudToDevice/temp/temp.json
@@ -33,6 +33,7 @@
     "additionalProperties":false,
     "required":[
        "appId",
-       "messageType"
+       "messageType",
+       "data"
     ]
  }

--- a/schemas/deviceToCloud/flip/flip.json
+++ b/schemas/deviceToCloud/flip/flip.json
@@ -33,8 +33,7 @@
     "required":[
        "appId",
        "messageType",
-       "data",
-       "ts"
+       "data"
     ],
     "additionalProperties":false
  }

--- a/schemas/deviceToCloud/flip/flip.json
+++ b/schemas/deviceToCloud/flip/flip.json
@@ -32,7 +32,9 @@
     },
     "required":[
        "appId",
-       "messageType"
+       "messageType",
+       "data",
+       "ts"
     ],
     "additionalProperties":false
  }

--- a/schemas/deviceToCloud/temp/temp.json
+++ b/schemas/deviceToCloud/temp/temp.json
@@ -30,6 +30,8 @@
     "additionalProperties":false,
     "required":[
        "appId",
-       "messageType"
+       "messageType",
+       "data",
+       "ts"
     ]
  }

--- a/schemas/deviceToCloud/temp/temp.json
+++ b/schemas/deviceToCloud/temp/temp.json
@@ -31,7 +31,6 @@
     "required":[
        "appId",
        "messageType",
-       "data",
-       "ts"
+       "data"
     ]
  }

--- a/schemas/deviceToCloud/wifi/wifi-position.json
+++ b/schemas/deviceToCloud/wifi/wifi-position.json
@@ -49,6 +49,9 @@
             "additionalProperties": false
         }
     },
+    "required": [
+        "data"
+    ],
     "definitions": {
         "MacAddress": {
             "type": "string",


### PR DESCRIPTION
Makes the `data` property on some message required because otherwise the message would be not useful.