### PR TITLE
D2C device: make appName, batteryVoltage optional

### DIFF
--- a/schemas/deviceToCloud/device/device.json
+++ b/schemas/deviceToCloud/device/device.json
@@ -130,9 +130,7 @@
                 }
             },
             "required": [
-                "appName",
                 "appVersion",
-                "batteryVoltage",
                 "board",
                 "imei",
                 "modemFirmware"


### PR DESCRIPTION
asset_tracker_v2 does not send it.

```json
{
    "appId": "DEVICE",
    "messageType": "DATA",
    "ts": 1676369307189,
    "data": {
      "deviceInfo": {
        "imei": "350457794611739",
        "iccid": "8931080620054223678",
        "modemFirmware": "mfw_nrf9160_1.3.3",
        "board": "thingy91_nrf9160",
        "appVersion": "0.0.0-development"
      }
    }
  }
```