### PR TITLE
refactor: remove 'hello' messages and fix test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Devices that send messages to nRFCloud can optionally have data displayed on car
 
 | MessageType      | Description | deviceToCloud or cloudToDevice |
 | :-----------:      | :----------- | :-----------:                    |
-| HELLO | Tells applications that device is ready to send data	  | C2D |
 | START | Tells application to start sending data to cloud	      | C2D |
 | STOP  | Tells device to stop sending data	                      | C2D |
 | INIT  | Tells the application to initialize or reset	          | C2D |

--- a/schemas/deviceToCloud/flip/flip-hello-example.json
+++ b/schemas/deviceToCloud/flip/flip-hello-example.json
@@ -1,4 +1,0 @@
-{
-    "appId": "FLIP",
-    "messageType": "HELLO"
-}

--- a/schemas/deviceToCloud/flip/flip.json
+++ b/schemas/deviceToCloud/flip/flip.json
@@ -10,7 +10,6 @@
        "messageType":{
           "type":"string",
           "enum":[
-             "HELLO",
              "DATA"
           ]
        },

--- a/schemas/deviceToCloud/temp/temp-hello-example.json
+++ b/schemas/deviceToCloud/temp/temp-hello-example.json
@@ -1,4 +1,0 @@
-{
-    "appId": "TEMP",
-    "messageType": "HELLO"
-}

--- a/schemas/deviceToCloud/temp/temp.json
+++ b/schemas/deviceToCloud/temp/temp.json
@@ -10,8 +10,7 @@
        "messageType":{
           "type":"string",
           "enum":[
-              "DATA",
-              "HELLO"
+              "DATA"
           ]
        },
        "data":{


### PR DESCRIPTION
### Problem
The HELLO messages are deprecated, but still in the repo. 

### Solution
Remove them.

### Testing
```bash
npm test
```

### Front End Changes Required
NONE

### System Impact
NONE

### Jira Tickets
IRIS-5889

### Release Notes
This came up because of the requirement to have the DATA property in every message, but the HELLO messages have no data property. There is no place on the backend where we support the HELLO message. @plskeggs has confirmed that this is true for the FW to the best of his knowledge. 