### PR TITLE
feat: added config flags to wifi, cell_position, and ground_fix

### DIFF
--- a/schemas/deviceToCloud/cell_position/cell-position-example.json
+++ b/schemas/deviceToCloud/cell_position/cell-position-example.json
@@ -1,8 +1,12 @@
 {
     "appId": "CELL_POS",
     "messageType": "DATA",
+    "config": {
+        "doReply": true,
+        "highConfidence": false,
+        "fallback": true
+    },
     "data": {
-        "doReply": false,
         "lte": [
             {
                 "mnc": 260,

--- a/schemas/deviceToCloud/cell_position/cell-position-example.json
+++ b/schemas/deviceToCloud/cell_position/cell-position-example.json
@@ -3,7 +3,7 @@
     "messageType": "DATA",
     "config": {
         "doReply": true,
-        "highConfidence": false,
+        "hiConf": false,
         "fallback": true
     },
     "data": {

--- a/schemas/deviceToCloud/cell_position/cell-position-with-neighbors-example.json
+++ b/schemas/deviceToCloud/cell_position/cell-position-with-neighbors-example.json
@@ -1,8 +1,12 @@
 {
     "appId": "CELL_POS",
     "messageType": "DATA",
+    "config": {
+        "doReply": true,
+        "highConfidence": false,
+        "fallback": true
+    },
     "data": {
-        "doReply": false,
         "lte": [
             {
                 "mnc": 260,

--- a/schemas/deviceToCloud/cell_position/cell-position-with-neighbors-example.json
+++ b/schemas/deviceToCloud/cell_position/cell-position-with-neighbors-example.json
@@ -3,7 +3,7 @@
     "messageType": "DATA",
     "config": {
         "doReply": true,
-        "highConfidence": false,
+        "hiConf": false,
         "fallback": true
     },
     "data": {

--- a/schemas/deviceToCloud/cell_position/cell-position.json
+++ b/schemas/deviceToCloud/cell_position/cell-position.json
@@ -15,7 +15,9 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply"
+                    "type": "boolean",
+                    "description": "Controls the response body. If false, response body will be empty.",
+                    "default": true
                 },
                 "highConfidence": {
                     "type": "boolean",
@@ -34,7 +36,9 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply",
+                    "type": ["boolean", "integer"],
+                    "description": "Controls the response body. If false or number 0, response body will be empty.",
+                    "default": true,
                     "deprecated": true
                 },
                 "lte": {
@@ -106,11 +110,6 @@
         }
     },
     "definitions": {
-        "DoReply": {
-            "type": "boolean",
-            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
-            "default": true
-        },
         "Mcc": {
             "type": "integer",
             "description": "Mobile Country Code"

--- a/schemas/deviceToCloud/cell_position/cell-position.json
+++ b/schemas/deviceToCloud/cell_position/cell-position.json
@@ -11,11 +11,31 @@
             "type": "string",
             "const": "DATA"
         },
-        "data": {
+        "config": {
             "type": "object",
             "properties": {
                 "doReply": {
                     "$ref": "#/definitions/DoReply"
+                },
+                "highConfidence": {
+                    "type": "boolean",
+                    "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
+                    "default": false
+                },
+                "fallback": {
+                    "type": "boolean",
+                    "description": "nRF Cloud will always return the most accurate response based on cell tower location or AP location for wifi, if available. When not available, nRF Cloud falls back to area-level location estimate based on cell tower tracking area code. To disable this behavior, set fallback=false. This will ignore cell tracking area and return a 404 in event a higher accuracy response cannot be provided.",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "doReply": {
+                    "$ref": "#/definitions/DoReply",
+                    "deprecated": true
                 },
                 "lte": {
                     "type": "array",
@@ -88,7 +108,8 @@
     "definitions": {
         "DoReply": {
             "type": "boolean",
-            "description": "Does not reply, even in event of an error, if set to false. Defaults to true."
+            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
+            "default": true
         },
         "Mcc": {
             "type": "integer",

--- a/schemas/deviceToCloud/cell_position/cell-position.json
+++ b/schemas/deviceToCloud/cell_position/cell-position.json
@@ -19,7 +19,7 @@
                     "description": "Controls the response body. If false, response body will be empty.",
                     "default": true
                 },
-                "highConfidence": {
+                "hiConf": {
                     "type": "boolean",
                     "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
                     "default": false

--- a/schemas/deviceToCloud/ground_fix/ground-fix-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-example.json
@@ -1,15 +1,19 @@
 {
     "appId": "GROUND_FIX",
     "messageType": "DATA",
+    "config": {
+        "doReply": true,
+        "highConfidence": false,
+        "fallback": true
+    },
     "data": {
-        "doReply": false,
         "wifi": {
             "accessPoints": [
                 {
-                  "macAddress": "fd:70:40:b9:58:dc"
+                    "macAddress": "fd:70:40:b9:58:dc"
                 },
                 {
-                  "macAddress": "c5:ab:c7:55:8d:e3"
+                    "macAddress": "c5:ab:c7:55:8d:e3"
                 }
             ]
         },

--- a/schemas/deviceToCloud/ground_fix/ground-fix-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-example.json
@@ -3,7 +3,7 @@
     "messageType": "DATA",
     "config": {
         "doReply": true,
-        "highConfidence": false,
+        "hiConf": false,
         "fallback": true
     },
     "data": {

--- a/schemas/deviceToCloud/ground_fix/ground-fix-lte-only-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-lte-only-example.json
@@ -1,8 +1,12 @@
 {
     "appId": "GROUND_FIX",
     "messageType": "DATA",
+    "config": {
+        "doReply": true,
+        "highConfidence": false,
+        "fallback": true
+    },
     "data": {
-        "doReply": false,
         "lte": [
             {
                 "mnc": 260,

--- a/schemas/deviceToCloud/ground_fix/ground-fix-lte-only-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-lte-only-example.json
@@ -3,7 +3,7 @@
     "messageType": "DATA",
     "config": {
         "doReply": true,
-        "highConfidence": false,
+        "hiConf": false,
         "fallback": true
     },
     "data": {

--- a/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
@@ -7,7 +7,6 @@
     "fallback": true
   },
   "data": {
-    "doReply": false,
     "wifi": {
       "accessPoints": [
         {

--- a/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
@@ -1,17 +1,22 @@
 {
-    "appId": "GROUND_FIX",
-    "messageType": "DATA",
-    "data": {
-        "doReply": false,
-        "wifi": {
-            "accessPoints": [
-                {
-                  "macAddress": "fd:70:40:b9:58:dc"
-                },
-                {
-                  "macAddress": "c5:ab:c7:55:8d:e3"
-                }
-            ]
+  "appId": "GROUND_FIX",
+  "messageType": "DATA",
+  "config": {
+    "doReply": true,
+    "highConfidence": false,
+    "fallback": true
+  },
+  "data": {
+    "doReply": false,
+    "wifi": {
+      "accessPoints": [
+        {
+          "macAddress": "fd:70:40:b9:58:dc"
+        },
+        {
+          "macAddress": "c5:ab:c7:55:8d:e3"
         }
+      ]
     }
+  }
 }

--- a/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-wifi-only-example.json
@@ -3,7 +3,7 @@
   "messageType": "DATA",
   "config": {
     "doReply": true,
-    "highConfidence": false,
+    "hiConf": false,
     "fallback": true
   },
   "data": {

--- a/schemas/deviceToCloud/ground_fix/ground-fix.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix.json
@@ -11,12 +11,32 @@
             "type": "string",
             "const": "DATA"
         },
+        "config": {
+            "type": "object",
+            "properties": {
+                "doReply": {
+                    "$ref": "#/definitions/DoReply"
+                },
+                "highConfidence": {
+                    "type": "boolean",
+                    "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
+                    "default": false
+                },
+                "fallback": {
+                    "type": "boolean",
+                    "description": "nRF Cloud will always return the most accurate response based on cell tower location or AP location for wifi, if available. When not available, nRF Cloud falls back to area-level location estimate based on cell tower tracking area code. To disable this behavior, set fallback=false. This will ignore cell tracking area and return a 404 in event a higher accuracy response cannot be provided.",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
+        },
         "data": {
             "type": "object",
             "minProperties": 1,
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply"
+                    "$ref": "#/definitions/DoReply",
+                    "deprecated": true
                 },
                 "wifi": {
                     "type": "object",
@@ -123,7 +143,8 @@
     "definitions": {
         "DoReply": {
             "type": "boolean",
-            "description": "Does not reply, even in event of an error, if set to false. Defaults to true."
+            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
+            "default": true
         },
         "Mcc": {
             "type": "integer",
@@ -188,10 +209,10 @@
             "description": "Channel number (only one of Channel or Frequency should be used)"
         }
     },
-    "required":[
+    "required": [
         "appId",
         "messageType",
         "data"
-     ],
-     "additionalProperties": false
+    ],
+    "additionalProperties": false
 }

--- a/schemas/deviceToCloud/ground_fix/ground-fix.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix.json
@@ -19,7 +19,7 @@
                     "description": "Controls the response body. If false, response body will be empty.",
                     "default": true
                 },
-                "highConfidence": {
+                "hiConf": {
                     "type": "boolean",
                     "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
                     "default": false

--- a/schemas/deviceToCloud/ground_fix/ground-fix.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix.json
@@ -15,7 +15,9 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply"
+                    "type": "boolean",
+                    "description": "Controls the response body. If false, response body will be empty.",
+                    "default": true
                 },
                 "highConfidence": {
                     "type": "boolean",
@@ -35,7 +37,9 @@
             "minProperties": 1,
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply",
+                    "type": ["boolean", "integer"],
+                    "description": "Controls the response body. If false or number 0, response body will be empty.",
+                    "default": true,
                     "deprecated": true
                 },
                 "wifi": {
@@ -141,11 +145,6 @@
         }
     },
     "definitions": {
-        "DoReply": {
-            "type": "boolean",
-            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
-            "default": true
-        },
         "Mcc": {
             "type": "integer",
             "description": "Mobile Country Code"

--- a/schemas/deviceToCloud/wifi/wifi-position-example.json
+++ b/schemas/deviceToCloud/wifi/wifi-position-example.json
@@ -1,14 +1,17 @@
 {
-    "appId": "WIFI",
-    "messageType": "DATA",
-    "data": {
-        "accessPoints": [
-            {
-              "macAddress": "fd:70:40:b9:58:dc"
-            },
-            {
-              "macAddress": "c5:ab:c7:55:8d:e3"
-            }
-        ]
-    }
+  "appId": "WIFI",
+  "messageType": "DATA",
+  "config": {
+    "doReply": true
+  },
+  "data": {
+    "accessPoints": [
+      {
+        "macAddress": "fd:70:40:b9:58:dc"
+      },
+      {
+        "macAddress": "c5:ab:c7:55:8d:e3"
+      }
+    ]
+  }
 }

--- a/schemas/deviceToCloud/wifi/wifi-position-with-doReply-example.json
+++ b/schemas/deviceToCloud/wifi/wifi-position-with-doReply-example.json
@@ -1,15 +1,17 @@
 {
-    "appId": "WIFI",
-    "messageType": "DATA",
-    "data": {
-        "doReply": false,
-        "accessPoints": [
-            {
-              "macAddress": "fd:70:40:b9:58:dc"
-            },
-            {
-              "macAddress": "c5:ab:c7:55:8d:e3"
-            }
-        ]
-    }
+  "appId": "WIFI",
+  "messageType": "DATA",
+  "config": {
+    "doReply": true
+  },
+  "data": {
+    "accessPoints": [
+      {
+        "macAddress": "fd:70:40:b9:58:dc"
+      },
+      {
+        "macAddress": "c5:ab:c7:55:8d:e3"
+      }
+    ]
+  }
 }

--- a/schemas/deviceToCloud/wifi/wifi-position.json
+++ b/schemas/deviceToCloud/wifi/wifi-position.json
@@ -11,11 +11,21 @@
             "type": "string",
             "const": "DATA"
         },
-        "data": {
+        "config": {
             "type": "object",
             "properties": {
                 "doReply": {
                     "$ref": "#/definitions/DoReply"
+                }
+            },
+            "additionalProperties": false
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "doReply": {
+                    "$ref": "#/definitions/DoReply",
+                    "deprecated": true
                 },
                 "accessPoints": {
                     "type": "array",
@@ -58,7 +68,8 @@
     "definitions": {
         "DoReply": {
             "type": "boolean",
-            "description": "Does not reply, even in event of an error, if set to false. Defaults to true."
+            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
+            "default": true
         },
         "MacAddress": {
             "type": "string",

--- a/schemas/deviceToCloud/wifi/wifi-position.json
+++ b/schemas/deviceToCloud/wifi/wifi-position.json
@@ -15,7 +15,9 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply"
+                    "type": "boolean",
+                    "description": "Controls the response body. If false, response body will be empty.",
+                    "default": true
                 }
             },
             "additionalProperties": false
@@ -24,7 +26,9 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "$ref": "#/definitions/DoReply",
+                    "type": ["boolean", "integer"],
+                    "description": "Controls the response body. If false or number 0, response body will be empty.",
+                    "default": true,
                     "deprecated": true
                 },
                 "accessPoints": {
@@ -66,11 +70,6 @@
         "data"
     ],
     "definitions": {
-        "DoReply": {
-            "type": "boolean",
-            "description": "Controls the response body. If boolean false or number 0, response body will be empty.",
-            "default": true
-        },
         "MacAddress": {
             "type": "string",
             "description": "String comprised of 6 hexadecimal pairs, separated by colons or dashes"


### PR DESCRIPTION
### Problem
MQTT does not have any of the config flags that currently exist on the REST API.

### Solution
Add them. [Sister PR here](https://github.com/nRFCloud/backend/pull/2268).

### Testing
```bash
npm test
```

### Front End Changes Required
NONE

### System Impact
NONE

### Jira Tickets
IRIS-7342

### Release Notes
Added config flags for cell, wifi, and ground_fix