### PR TITLE
refactor: revert 'mac' to 'macAddress'

### DIFF
--- a/schemas/cloudToDevice/ground_fix/ground-fix-example-with-extras.json
+++ b/schemas/cloudToDevice/ground_fix/ground-fix-example-with-extras.json
@@ -7,7 +7,7 @@
         "uncertainty": 500,
         "fulfilledWith": "ANCHOR",
         "anchors": [{ 
-            "mac": "9F:11:7D:3A:4F:FF",
+            "macAddress": "9F:11:7D:3A:4F:FF",
             "name": "PDX office"
         }]
     }

--- a/schemas/cloudToDevice/ground_fix/ground-fix.json
+++ b/schemas/cloudToDevice/ground_fix/ground-fix.json
@@ -31,10 +31,10 @@
                "items": {
                   "type": "object",
                   "properties": {
-                     "mac": { "type": "string", "pattern": "^((([0-9A-F]{2}:){5})|([0-9A-F]{10}))([0-9A-F]{2})$" },
+                     "macAddress": { "type": "string", "pattern": "^((([0-9A-F]{2}:){5})|([0-9A-F]{10}))([0-9A-F]{2})$" },
                      "name": { "type": "string" }
                   },
-                  "required": ["mac"],
+                  "required": ["macAddress"],
                   "additionalProperties": false
                }
             }

--- a/schemas/cloudToDevice/wifi/wifi-position-example-extras.json
+++ b/schemas/cloudToDevice/wifi/wifi-position-example-extras.json
@@ -6,7 +6,7 @@
         "lon": 100.93402931,
         "uncertainty": 70,
         "anchors": [{ 
-            "mac": "9F:11:7D:3A:4F:FF",
+            "macAddress": "9F:11:7D:3A:4F:FF",
             "name": "warehouse 1"
         }]
     }

--- a/schemas/cloudToDevice/wifi/wifi-position.json
+++ b/schemas/cloudToDevice/wifi/wifi-position.json
@@ -28,7 +28,7 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "mac": {
+                            "macAddress": {
                                 "type": "string",
                                 "pattern": "^((([0-9A-F]{2}:){5})|([0-9A-F]{10}))([0-9A-F]{2})$"
                             },
@@ -37,7 +37,7 @@
                             }
                         },
                         "required": [
-                            "mac"
+                            "macAddress"
                         ],
                         "additionalProperties": false
                     }


### PR DESCRIPTION
### Problem
Changing `macAddress` to `mac` was implemented to reduce payload size alongside a few other changes like removing `meta` property and shortening `highConfidence` to `hiConf`. We use `macAddress` elsewhere in the system and having 2 ways to reference the same property is poor API design. So is having different response formats for the same request. 

[Sister PR here](https://github.com/nRFCloud/backend/pull/2289).

### Solution
Change it back to `macAddress`. 

### Testing
```bash
npm test
```

### Front End Changes Required
NONE

### System Impact
NONE

### Jira Tickets
IRIS-7474

### Release Notes
Reverted `mac` to `macAddress`. 
