### PR TITLE
feat: added 'hiConf' flag for wifi

### DIFF
--- a/schemas/deviceToCloud/wifi/wifi-position-example.json
+++ b/schemas/deviceToCloud/wifi/wifi-position-example.json
@@ -2,7 +2,8 @@
   "appId": "WIFI",
   "messageType": "DATA",
   "config": {
-    "doReply": true
+    "doReply": true,
+    "hiConf": true
   },
   "data": {
     "accessPoints": [

--- a/schemas/deviceToCloud/wifi/wifi-position.json
+++ b/schemas/deviceToCloud/wifi/wifi-position.json
@@ -18,6 +18,11 @@
                     "type": "boolean",
                     "description": "Controls the response body. If false, response body will be empty.",
                     "default": true
+                },
+                "hiConf": {
+                    "type": "boolean",
+                    "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
+                    "default": false
                 }
             },
             "additionalProperties": false
@@ -26,7 +31,10 @@
             "type": "object",
             "properties": {
                 "doReply": {
-                    "type": ["boolean", "integer"],
+                    "type": [
+                        "boolean",
+                        "integer"
+                    ],
                     "description": "Controls the response body. If false or number 0, response body will be empty.",
                     "default": true,
                     "deprecated": true

--- a/utilities.ts
+++ b/utilities.ts
@@ -2,7 +2,7 @@ import Ajv, { Schema } from 'ajv/dist/2020';
 
 export const isValidSchema = (schema: Schema, example: unknown): boolean => {
     const ajv = new Ajv({
-        strict: 'log',
+        strict: false,
         verbose: true,
         strictSchema: 'log',
     });


### PR DESCRIPTION
** This should not be merged until 11/29 release **

### Problem
1. Wifi REST endpoint accepts the `hiConf` flag and so does MQTT, but it is not documented.
2. Strict mode is enabled for AJV

[Sister PR here](https://github.com/nRFCloud/backend/pull/2318)

### Solution
1. Document it.
2. Disable strict mode

### Testing
```bash
npm run test
```

### Front End Changes Required
NONE

### System Impact
NONE

### Jira Tickets
IRIS-7507

### Release Notes
Added hiConf flag to DeviceToCloud.Wifi