### PR TITLE
fix: hide contribution API endpoint

### DIFF
--- a/__tests__/schemas.spec.ts
+++ b/__tests__/schemas.spec.ts
@@ -53,17 +53,8 @@ describe(header('device shadow'), () => {
 
 describe('Validate example for dependencies', () => {
     it('can correctly load device shadow', () => {
-        const exampleData = JSON.parse(
-            readFileSync(
-                './schemas/deviceShadow/ipShadow/ipShadow-example.json',
-                'utf-8',
-            ),
-        );
-        const valid = getValidationWithDependencies(
-            DeviceShadow.IP,
-            [DeviceShadow.Config],
-            exampleData,
-        );
+        const exampleData = JSON.parse(readFileSync('./schemas/deviceShadow/ipShadow/ipShadow-example.json', 'utf-8'));
+        const valid = getValidationWithDependencies(DeviceShadow.IP, [DeviceShadow.Config], exampleData);
         expect(valid).toBeTruthy();
-    });
+    }); 
 });

--- a/schemas/deviceToCloud/cell_position/cell-position-example.json
+++ b/schemas/deviceToCloud/cell_position/cell-position-example.json
@@ -4,8 +4,7 @@
     "config": {
         "doReply": true,
         "hiConf": false,
-        "fallback": true,
-        "cont": false
+        "fallback": true
     },
     "data": {
         "lte": [

--- a/schemas/deviceToCloud/cell_position/cell-position.json
+++ b/schemas/deviceToCloud/cell_position/cell-position.json
@@ -28,11 +28,6 @@
                     "type": "boolean",
                     "description": "nRF Cloud will always return the most accurate response based on cell tower location or AP location for wifi, if available. When not available, nRF Cloud falls back to area-level location estimate based on cell tower tracking area code. To disable this behavior, set fallback=false. This will ignore cell tracking area and return a 404 in event a higher accuracy response cannot be provided.",
                     "default": true
-                },
-                "cont": {
-                    "type": "boolean",
-                    "description": "nRF Cloud automatically uses your contributions to override our usual location response. To disable this behavior, set cont=false. This will ignore the contributions and proceed with the usual process for resolving your location.",
-                    "default": true
                 }
             },
             "additionalProperties": false
@@ -68,7 +63,7 @@
                             },
                             "rsrq": {
                                 "$ref": "#/definitions/Rsrq"
-                            },
+                            }, 
                             "earfcn": {
                                 "$ref": "#/definitions/Earfcn"
                             },

--- a/schemas/deviceToCloud/ground_fix/ground-fix-example.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix-example.json
@@ -4,8 +4,7 @@
     "config": {
         "doReply": true,
         "hiConf": false,
-        "fallback": true,
-        "cont": false
+        "fallback": true
     },
     "data": {
         "wifi": {

--- a/schemas/deviceToCloud/ground_fix/ground-fix.json
+++ b/schemas/deviceToCloud/ground_fix/ground-fix.json
@@ -28,11 +28,6 @@
                     "type": "boolean",
                     "description": "nRF Cloud will always return the most accurate response based on cell tower location or AP location for wifi, if available. When not available, nRF Cloud falls back to area-level location estimate based on cell tower tracking area code. To disable this behavior, set fallback=false. This will ignore cell tracking area and return a 404 in event a higher accuracy response cannot be provided.",
                     "default": true
-                },
-                "cont": {
-                    "type": "boolean",
-                    "description": "nRF Cloud automatically uses your contributions to override our usual location response. To disable this behavior, set cont=false. This will ignore the contributions and proceed with the usual process for resolving your location.",
-                    "default": true
                 }
             },
             "additionalProperties": false

--- a/schemas/deviceToCloud/wifi/wifi-position-example.json
+++ b/schemas/deviceToCloud/wifi/wifi-position-example.json
@@ -3,8 +3,7 @@
   "messageType": "DATA",
   "config": {
     "doReply": true,
-    "hiConf": true,
-    "cont": false
+    "hiConf": true
   },
   "data": {
     "accessPoints": [

--- a/schemas/deviceToCloud/wifi/wifi-position.json
+++ b/schemas/deviceToCloud/wifi/wifi-position.json
@@ -23,11 +23,6 @@
                     "type": "boolean",
                     "description": "nRF Cloud automatically uses a 68% confidence interval when estimating the Horizontal Positioning Error (HPE) for a location. This means that there is a 68% probability that the device's actual location is within the HPE radius of the returned coordinates. Enabling this flag will use a 95% confidence interval instead, resulting in a larger HPE radius, and a higher probability that the device's actual location is within the circle.",
                     "default": false
-                },
-                "cont": {
-                    "type": "boolean",
-                    "description": "nRF Cloud automatically uses your contributions to override our usual location response. To disable this behavior, set cont=false. This will ignore the contributions and proceed with the usual process for resolving your location.",
-                    "default": true
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
Sister PR: https://github.com/nRFCloud/backend/pull/3120

### Jira Tickets
IRIS-9501

### Problem
QA and docs are swamped and cannot evaluate the Contribution API feature this release cycle.

### Solution
Disable the endpoint and hide it from the docs.

### Testing
```bash
npm test
```

### Implications for Front End
NONE

### Implications for Customer Documentation
Remove contribution API from rest api docs

### System Impact
NONE

#### Manual Install or Upgrade Steps
NONE

### Release Notes
Hid Contribution API feature from REST API.
