### PR TITLE
chore(actions): pin all github action digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
         name: Run Typescript Build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+            - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
               with:
                   node-version: 16
             - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
         name: Run Tests
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+            - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
               with:
                   node-version: 16
             - name: Install Dependencies


### PR DESCRIPTION
### Summary

Per [SDLC Governance Basics for SOC 2 Compliance](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/2831843831/SDLC+Governance+Basics+for+SOC+2+Compliance), all GitHub actions
should be pinned to their digest SHA to prevent supply chain attacks
that exploit mutable version tags.

For this PR I ran the following automated script to find and pin any
unpinned github actions:

```bash
npx -p github:memfault/npx pin-github-actions -y
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
